### PR TITLE
Fix: AI sidebar feature save buttons not working correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
 		"lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
 		"lint:php": "composer run lint",
-		"lint:php:fix": "composer run lint:fix"
+		"lint:php:fix": "composer run lint:fix",
+		"ci": "yarn test:js && yarn lint:js && yarn lint:php"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.22.11",

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -53,14 +53,33 @@ const Headline = (): JSX.Element => {
 
 		const aiHeadline = response.trim().replace( /^"|"$/g, '' );
 
-		let limit = 1;
-		const showAnimatedAiText = setInterval( () => {
-			if ( aiHeadline.length === limit ) {
-				clearInterval( showAnimatedAiText );
-			}
-			setHeadline( aiHeadline.substring( 0, limit ) );
-			limit++;
-		}, 5 );
+		/**
+		 * This function returns a promise that resolves
+		 * to the AI generated headline when the Animation
+		 * responsible for showing same is completed.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @return { Promise<string> } Animated text.
+		 */
+		const showAnimatedAiText = (): Promise< string > => {
+			let limit = 1;
+
+			return new Promise( ( resolve ) => {
+				const animatedTextInterval = setInterval( () => {
+					if ( aiHeadline.length === limit ) {
+						clearInterval( animatedTextInterval );
+						resolve( aiHeadline );
+					}
+					setHeadline( aiHeadline.substring( 0, limit ) );
+					limit++;
+				}, 5 );
+			} );
+		};
+
+		showAnimatedAiText().then( ( newHeadline ) => {
+			editPost( { meta: { apbe_headline: newHeadline } } );
+		} );
 
 		setIsLoading( false );
 	};

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -76,16 +76,32 @@ const Headline = (): JSX.Element => {
 	const handleSelection = (): void => {
 		let limit = 1;
 
-		const showAnimatedAiText = setInterval( () => {
-			if ( limit === headline.length ) {
-				clearInterval( showAnimatedAiText );
-			}
-			editPost( { title: headline.substring( 0, limit ) } );
-			limit++;
-		}, 5 );
+		/**
+		 * This function returns a promise that
+		 * resolves to the headline when the Animation responsible
+		 * for showing the headline is completed.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @return { Promise<string> } Animated text.
+		 */
+		const showAnimatedAiText = (): Promise< string > => {
+			return new Promise( ( resolve ) => {
+				const animatedTextInterval = setInterval( () => {
+					if ( limit === headline.length ) {
+						clearInterval( animatedTextInterval );
+						resolve( headline );
+					}
+					editPost( { title: headline.substring( 0, limit ) } );
+					limit++;
+				}, 5 );
+			} );
+		};
 
-		editPost( { meta: { apbe_headline: headline } } );
-		savePost();
+		showAnimatedAiText().then( ( newHeadline ) => {
+			editPost( { meta: { apbe_headline: newHeadline } } );
+			savePost();
+		} );
 	};
 
 	return (

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -20,13 +20,9 @@ import Toast from '../components/Toast';
 const Headline = (): JSX.Element => {
 	const [ headline, setHeadline ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost } = dispatch( 'core/editor' ) as any;
-	const {
-		getCurrentPostId,
-		getEditedPostAttribute,
-		getEditedPostContent,
-		savePost,
-	} = select( 'core/editor' );
+	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
+		select( 'core/editor' );
 
 	const content = getEditedPostContent();
 

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -20,13 +20,9 @@ import Toast from '../components/Toast';
 const SEO = (): JSX.Element => {
 	const [ keywords, setKeywords ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost } = dispatch( 'core/editor' ) as any;
-	const {
-		getCurrentPostId,
-		getEditedPostAttribute,
-		getEditedPostContent,
-		savePost,
-	} = select( 'core/editor' );
+	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
+		select( 'core/editor' );
 
 	const content = getEditedPostContent();
 

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -51,14 +51,33 @@ const SEO = (): JSX.Element => {
 			},
 		} );
 
-		let limit = 1;
-		const showAnimatedAiText = setInterval( () => {
-			if ( aiKeywords.length === limit ) {
-				clearInterval( showAnimatedAiText );
-			}
-			setKeywords( aiKeywords.substring( 0, limit ) );
-			limit++;
-		}, 5 );
+		/**
+		 * This function returns a promise that resolves
+		 * to the AI generated SEO keywords when the Animation
+		 * responsible for showing same is completed.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @return { Promise<string> } Animated text.
+		 */
+		const showAnimatedAiText = (): Promise< string > => {
+			let limit = 1;
+
+			return new Promise( ( resolve ) => {
+				const animatedTextInterval = setInterval( () => {
+					if ( aiKeywords.length === limit ) {
+						clearInterval( animatedTextInterval );
+						resolve( aiKeywords );
+					}
+					setKeywords( aiKeywords.substring( 0, limit ) );
+					limit++;
+				}, 5 );
+			} );
+		};
+
+		showAnimatedAiText().then( ( newKeywords ) => {
+			editPost( { meta: { apbe_seo_keywords: newKeywords } } );
+		} );
 
 		setIsLoading( false );
 	};

--- a/src/components/Slug.tsx
+++ b/src/components/Slug.tsx
@@ -20,13 +20,9 @@ import Toast from '../components/Toast';
 const Slug = (): JSX.Element => {
 	const [ slug, setSlug ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost } = dispatch( 'core/editor' ) as any;
-	const {
-		getCurrentPostId,
-		getEditedPostContent,
-		getEditedPostAttribute,
-		savePost,
-	} = select( 'core/editor' );
+	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { getCurrentPostId, getEditedPostContent, getEditedPostAttribute } =
+		select( 'core/editor' );
 
 	const content = getEditedPostContent();
 

--- a/src/components/Slug.tsx
+++ b/src/components/Slug.tsx
@@ -51,14 +51,34 @@ const Slug = (): JSX.Element => {
 			},
 		} );
 
-		let limit = 1;
-		const showAnimatedAiText = setInterval( () => {
-			if ( aiSlug.length === limit ) {
-				clearInterval( showAnimatedAiText );
-			}
-			setSlug( aiSlug.substring( 0, limit ) );
-			limit++;
-		}, 5 );
+		/**
+		 * This function returns a promise that resolves
+		 * to the AI generated slug when the Animation responsible
+		 * for showing same is completed.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @return { Promise<string> } Animated text.
+		 */
+		const showAnimatedAiText = (): Promise< string > => {
+			let limit = 1;
+
+			return new Promise( ( resolve ) => {
+				const animatedTextInterval = setInterval( () => {
+					if ( aiSlug.length === limit ) {
+						clearInterval( animatedTextInterval );
+						resolve( aiSlug );
+					}
+					setSlug( aiSlug.substring( 0, limit ) );
+					limit++;
+				}, 5 );
+			} );
+		};
+
+		showAnimatedAiText().then( ( newSlug ) => {
+			editPost( { slug: newSlug } );
+			editPost( { meta: { apbe_slug: newSlug } } );
+		} );
 
 		setIsLoading( false );
 	};

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -20,13 +20,9 @@ import Toast from '../components/Toast';
 const Summary = (): JSX.Element => {
 	const [ summary, setSummary ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost } = dispatch( 'core/editor' ) as any;
-	const {
-		getCurrentPostId,
-		getEditedPostContent,
-		getEditedPostAttribute,
-		savePost,
-	} = select( 'core/editor' );
+	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { getCurrentPostId, getEditedPostContent, getEditedPostAttribute } =
+		select( 'core/editor' );
 
 	const content = getEditedPostContent();
 

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -51,14 +51,34 @@ const Summary = (): JSX.Element => {
 			},
 		} );
 
-		let limit = 1;
-		const showAnimatedAiText = setInterval( () => {
-			if ( aiSummary.length === limit ) {
-				clearInterval( showAnimatedAiText );
-			}
-			setSummary( aiSummary.substring( 0, limit ) );
-			limit++;
-		}, 5 );
+		/**
+		 * This function returns a promise that resolves
+		 * to the AI generated summary when the Animation
+		 * responsible for showing same is completed.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @return { Promise<string> } Animated text.
+		 */
+		const showAnimatedAiText = (): Promise< string > => {
+			let limit = 1;
+
+			return new Promise( ( resolve ) => {
+				const animatedTextInterval = setInterval( () => {
+					if ( aiSummary.length === limit ) {
+						clearInterval( animatedTextInterval );
+						resolve( aiSummary );
+					}
+					setSummary( aiSummary.substring( 0, limit ) );
+					limit++;
+				}, 5 );
+			} );
+		};
+
+		showAnimatedAiText().then( ( newSummary ) => {
+			editPost( { excerpt: newSummary } );
+			editPost( { meta: { apbe_summary: newSummary } } );
+		} );
 
 		setIsLoading( false );
 	};


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/3).

## Description / Background Context

At the moment, when any of the AI Sidebar features (Headline, SEO Keywords and so on...) is selected, it makes the post dirty but does not save. The expected behaviour should be that it saves the AI feature. The `savePost` should be deconstructed from the dispatch. From the code it appears, that is the major culprit.

<img width="433" alt="Image" src="https://github.com/user-attachments/assets/53a2b412-d03f-4a8a-a277-db587eb55653" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn build`.
3. Generate a headline using the AI sidebar feature and click on the selection button.
4. It should now wait until the title field is populated before saving.
5. All other sidebar features should now work correctly and save the post.