### PR TITLE
Chore: Add local dev env setup for WP

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -4,6 +4,7 @@
 .eslintrc.js
 .gitignore
 .github
+.wp-env.json
 CHANGELOG.md
 jest.config.js
 jest.setup.js
@@ -16,6 +17,7 @@ phpstan.neon
 src
 assets
 tests
+bin
 vendor/orhanerday/open-ai/files/assistant-file.txt
 vendor/orhanerday/open-ai/files/en-marvel-endgame.m4a
 vendor/orhanerday/open-ai/files/sample_file_1.jsonl

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,17 @@
+{
+	"plugins": [
+		"."
+	],
+	"phpVersion": "8.2",
+	"port": 5487,
+	"testsPort": 5488,
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_SITEURL": "http://apbe.localhost",
+		"WP_HOME": "http://apbe.localhost"
+	},
+	"lifecycleScripts": {
+		"afterStart": "./bin/setup.sh"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -164,3 +164,32 @@ public function custom_route( $rest_routes ) {
 - rest_routes _`{array}`_ By default this will be an array containing the plugin's REST routes.
 <br/>
 
+---
+
+## Contribute
+
+Contributions are __welcome__ and will be fully __credited__. To contribute, please fork this repo and raise a PR (Pull Request) against the `master` branch.
+
+### Pre-requisites
+
+You should have the following tools before proceeding to the next steps:
+
+- Composer
+- Yarn
+- Docker
+
+To enable you start development, please run:
+
+```bash
+yarn start
+```
+
+This should spin up a local WP env instance for you to work with at:
+
+```bash
+http://apbe.localhost:5487
+```
+
+You should now have a functioning local WP env to work with.
+
+__Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/README.md
+++ b/README.md
@@ -190,6 +190,6 @@ This should spin up a local WP env instance for you to work with at:
 http://apbe.localhost:5487
 ```
 
-You should now have a functioning local WP env to work with.
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
 
 __Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+wp-env run cli wp rewrite structure /%postname%
+wp-env run cli wp theme activate twentytwentythree

--- a/package.json
+++ b/package.json
@@ -6,16 +6,20 @@
 	"license": "GPL-2.0-or-later",
 	"homepage": "https://github.com/badasswp/ai-plus-block-editor#readme",
 	"scripts": {
-		"start": "composer install && yarn install && yarn build",
+		"start": "yarn boot && yarn build && yarn wp-env start",
+		"stop": "yarn wp-env stop",
 		"watch": "webpack --watch",
 		"build": "webpack",
+		"boot": "composer install && yarn install",
 		"test": "npm-run-all --parallel test:*",
 		"test:js": "jest --passWithNoTests",
 		"lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
 		"lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
 		"lint:php": "composer run lint",
 		"lint:php:fix": "composer run lint:fix",
-		"ci": "yarn test:js && yarn lint:js && yarn lint:php"
+		"ci": "yarn test:js && yarn lint:js && yarn lint:php",
+		"wp-env": "wp-env",
+		"bash": "wp-env run cli bash"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.22.11",
@@ -26,6 +30,7 @@
 		"@testing-library/jest-dom": "5.17",
 		"@testing-library/react": "15.0.6",
 		"@types/jest": "^29.5.4",
+		"@wordpress/env": "^10.20.0",
 		"@wordpress/eslint-plugin": "^22.6.0",
 		"@wordpress/scripts": "^26.9.0",
 		"css-loader": "^6.8.1",


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/5).

## Description / Background Context

At the moment, contributors have to use their own methods of setting up this repo. We need to provide a consistent way for users to spin up this project's repo and contribute quickly perhaps using WP's `wp-env` so that users can now spin up their local instance by running:

```bash
yarn wp-env start
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. The repo should now build and boot up the `wp-env` instance ready for the user.
4. User should be able to access the site at: `http://apbe.localhost:5487`