### PR TITLE
Fix: Issue of super-imposed block-editor notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## 1.2.0
-* Enforce WP linting style across plugin.
+* Feat: Add local development environment setup.
+* Fix: AI sidebar feature save buttons not working correctly.
+* Fix: Deal with the issue of super-imposed notices.
+* Chore: Enforce WP listing across plugin.
+* Tested up to WP 6.7.2.
 
 ## 1.1.2
 * Refactor: AI client instance, make interchangeable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Feat: Add local development environment setup.
 * Fix: AI sidebar feature save buttons not working correctly.
 * Fix: Deal with the issue of super-imposed notices.
-* Chore: Enforce WP listing across plugin.
+* Chore: Enforce WP linting style across plugin.
 * Tested up to WP 6.7.2.
 
 ## 1.1.2

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-wp-env run cli wp rewrite structure /%postname%
 wp-env run cli wp theme activate twentytwentythree
+wp-env run cli wp rewrite structure /%postname%

--- a/readme.txt
+++ b/readme.txt
@@ -68,7 +68,11 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.2.0 =
-* Enforce WP linting style across plugin.
+* Feat: Add local development environment setup.
+* Fix: AI sidebar feature save buttons not working correctly.
+* Fix: Deal with the issue of super-imposed notices.
+* Chore: Enforce WP listing across plugin.
+* Tested up to WP 6.7.2.
 
 = 1.1.2 =
 * Refactor: AI client instance, make interchangeable.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Feat: Add local development environment setup.
 * Fix: AI sidebar feature save buttons not working correctly.
 * Fix: Deal with the issue of super-imposed notices.
-* Chore: Enforce WP listing across plugin.
+* Chore: Enforce WP linting style across plugin.
 * Tested up to WP 6.7.2.
 
 = 1.1.2 =

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { select, dispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 import { Button, Icon, TextareaControl } from '@wordpress/components';
+import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
@@ -20,11 +21,16 @@ import Toast from '../components/Toast';
 const Headline = (): JSX.Element => {
 	const [ headline, setHeadline ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const { removeNotice } = useDispatch( noticesStore );
 	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
 	const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
 		select( 'core/editor' );
 
 	const content = getEditedPostContent();
+	const notices = useSelect(
+		( use ) => use( noticesStore ).getNotices(),
+		[]
+	);
 
 	useEffect( () => {
 		setHeadline( getEditedPostAttribute( 'meta' ).apbe_headline );
@@ -39,6 +45,7 @@ const Headline = (): JSX.Element => {
 	 * @return { void }
 	 */
 	const handleClick = async (): Promise< void > => {
+		notices.forEach( ( notice ) => removeNotice( notice.id ) );
 		setIsLoading( true );
 
 		const response: string = await apiFetch( {

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { select, dispatch } from '@wordpress/data';
-import { Button, TextareaControl, Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { Button, TextareaControl, Icon } from '@wordpress/components';
+import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
@@ -20,11 +21,16 @@ import Toast from '../components/Toast';
 const SEO = (): JSX.Element => {
 	const [ keywords, setKeywords ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const { removeNotice } = useDispatch( noticesStore );
 	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
 	const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
 		select( 'core/editor' );
 
 	const content = getEditedPostContent();
+	const notices = useSelect(
+		( use ) => use( noticesStore ).getNotices(),
+		[]
+	);
 
 	useEffect( () => {
 		setKeywords( getEditedPostAttribute( 'meta' ).apbe_seo_keywords );
@@ -39,6 +45,7 @@ const SEO = (): JSX.Element => {
 	 * @return { void }
 	 */
 	const handleClick = async (): Promise< void > => {
+		notices.forEach( ( notice ) => removeNotice( notice.id ) );
 		setIsLoading( true );
 
 		const aiKeywords: string = await apiFetch( {

--- a/src/components/Slug.tsx
+++ b/src/components/Slug.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { select, dispatch } from '@wordpress/data';
-import { Button, TextControl, Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { Button, TextControl, Icon } from '@wordpress/components';
+import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
@@ -20,11 +21,16 @@ import Toast from '../components/Toast';
 const Slug = (): JSX.Element => {
 	const [ slug, setSlug ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const { removeNotice } = useDispatch( noticesStore );
 	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
 	const { getCurrentPostId, getEditedPostContent, getEditedPostAttribute } =
 		select( 'core/editor' );
 
 	const content = getEditedPostContent();
+	const notices = useSelect(
+		( use ) => use( noticesStore ).getNotices(),
+		[]
+	);
 
 	useEffect( () => {
 		setSlug( getEditedPostAttribute( 'meta' ).apbe_slug );
@@ -39,6 +45,7 @@ const Slug = (): JSX.Element => {
 	 * @return { void }
 	 */
 	const handleClick = async (): Promise< void > => {
+		notices.forEach( ( notice ) => removeNotice( notice.id ) );
 		setIsLoading( true );
 
 		const aiSlug: string = await apiFetch( {

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { select, dispatch } from '@wordpress/data';
-import { Button, TextareaControl, Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { Button, TextareaControl, Icon } from '@wordpress/components';
+import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
@@ -20,11 +21,16 @@ import Toast from '../components/Toast';
 const Summary = (): JSX.Element => {
 	const [ summary, setSummary ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const { removeNotice } = useDispatch( noticesStore );
 	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
 	const { getCurrentPostId, getEditedPostContent, getEditedPostAttribute } =
 		select( 'core/editor' );
 
 	const content = getEditedPostContent();
+	const notices = useSelect(
+		( use ) => use( noticesStore ).getNotices(),
+		[]
+	);
 
 	useEffect( () => {
 		setSummary( getEditedPostAttribute( 'meta' ).apbe_summary );
@@ -39,6 +45,7 @@ const Summary = (): JSX.Element => {
 	 * @return { void }
 	 */
 	const handleClick = async (): Promise< void > => {
+		notices.forEach( ( notice ) => removeNotice( notice.id ) );
 		setIsLoading( true );
 
 		const aiSummary: string = await apiFetch( {

--- a/tests/js/Headline.test.tsx
+++ b/tests/js/Headline.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 import Headline from '../../src/components/Headline';
 
@@ -39,6 +39,10 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn( () => ( {
+		removeNotice: jest.fn(),
+	} ) ),
 	dispatch: jest.fn( ( store ) =>
 		store === 'core/editor'
 			? {
@@ -62,6 +66,8 @@ jest.mock( '@wordpress/data', () => ( {
 			  }
 			: {}
 	),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
 } ) );
 
 describe( 'Headline', () => {

--- a/tests/js/SEO.test.tsx
+++ b/tests/js/SEO.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 import SEO from '../../src/components/SEO';
 
@@ -39,6 +39,10 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn( () => ( {
+		removeNotice: jest.fn(),
+	} ) ),
 	dispatch: jest.fn( ( store ) =>
 		store === 'core/editor'
 			? {
@@ -62,6 +66,8 @@ jest.mock( '@wordpress/data', () => ( {
 			  }
 			: {}
 	),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
 } ) );
 
 describe( 'SEO', () => {

--- a/tests/js/Slug.test.tsx
+++ b/tests/js/Slug.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 import Slug from '../../src/components/Slug';
 
@@ -59,6 +59,10 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn( () => ( {
+		removeNotice: jest.fn(),
+	} ) ),
 	dispatch: jest.fn( ( store ) =>
 		store === 'core/editor'
 			? {
@@ -82,6 +86,8 @@ jest.mock( '@wordpress/data', () => ( {
 			  }
 			: {}
 	),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
 } ) );
 
 describe( 'Slug', () => {

--- a/tests/js/Summary.test.tsx
+++ b/tests/js/Summary.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 import Summary from '../../src/components/Summary';
 
@@ -39,6 +39,10 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn( () => ( {
+		removeNotice: jest.fn(),
+	} ) ),
 	dispatch: jest.fn( ( store ) =>
 		store === 'core/editor'
 			? {
@@ -62,6 +66,8 @@ jest.mock( '@wordpress/data', () => ( {
 			  }
 			: {}
 	),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
 } ) );
 
 describe( 'Summary', () => {

--- a/tests/js/Toast.test.tsx
+++ b/tests/js/Toast.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 import Toast from '../../src/components/Toast';
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/7).

## Description / Background Context

When the save or publish button is clicked, and then any of the generate buttons is clicked, the notices appear super imposed. This results in a distorted view of the notices.

---

<img width="419" alt="Screenshot 2025-03-23 at 14 28 57" src="https://github.com/user-attachments/assets/07ab66a0-8a18-467a-8728-443359986f00" />

---

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Open a post and enable the AI Plus Block Editor panel.
4. Now click on the save button and then click on the generate button.
5. The notices should no more be blocking each other.