### PR TITLE
Fix: Gracefully deal with WP REST error responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Run JS Unit Tests
       run: |
-        yarn test
+        yarn test:js
 
     - name: Set up PHP v8.2
       uses: shivammathur/setup-php@v2

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,8 +6,6 @@
 	"port": 5487,
 	"testsPort": 5488,
 	"config": {
-		"WP_DEBUG": true,
-		"WP_DEBUG_LOG": true,
 		"WP_SITEURL": "http://apbe.localhost",
 		"WP_HOME": "http://apbe.localhost"
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.2.0
+* Fix: Gracefully deal with WP REST error responses.
 * Feat: Add local development environment setup.
 * Fix: AI sidebar feature save buttons not working correctly.
 * Fix: Deal with the issue of super-imposed notices.

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
 		"boot": "composer install && yarn install",
 		"test": "npm-run-all --parallel test:*",
 		"test:js": "jest --passWithNoTests",
+		"test:php": "composer run test",
 		"lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
 		"lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
 		"lint:php": "composer run lint",
 		"lint:php:fix": "composer run lint:fix",
-		"ci": "yarn test:js && yarn lint:js && yarn lint:php",
+		"ci": "yarn test:js && yarn lint:js && yarn test:php && yarn lint:php",
 		"wp-env": "wp-env",
 		"bash": "wp-env run cli bash"
 	},

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.2.0 =
+* Fix: Gracefully deal with WP REST error responses.
 * Feat: Add local development environment setup.
 * Fix: AI sidebar feature save buttons not working correctly.
 * Fix: Deal with the issue of super-imposed notices.


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/9).

## Description / Background Context

At the moment when users try to generate an AI related content, no response is communicated back to the user if there is an error. When the user hits the **Generate** button, we need to effectively catch API call error responses sent back from the LLM to ensure users are presented with a notice of what has happened.

<img width="367" alt="Image" src="https://github.com/user-attachments/assets/2518dc5b-7740-4665-b0a9-71f7cd9f900c" />

----

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Head over to the settings page and erase your API keys and save.
4. Now head back to the block editor and try to generate an AI summary.
5. You should now see the error notice thrown at the top of the Block editor like so:

<img width="367" alt="Image" src="https://github.com/user-attachments/assets/2518dc5b-7740-4665-b0a9-71f7cd9f900c" />