### PR TITLE
Refactor: Sidebar components to adopt useSelect and useDispatch

### DIFF
--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -1,12 +1,18 @@
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 import { useState, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button, Icon, TextareaControl } from '@wordpress/components';
-import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
+
+interface selectProps {
+	getCurrentPostId: () => number;
+	getEditedPostContent: () => any;
+	getEditedPostAttribute: ( attribute: string ) => any;
+}
 
 /**
  * Headline.
@@ -19,22 +25,33 @@ import Toast from '../components/Toast';
  * @return {JSX.Element} Headline.
  */
 const Headline = (): JSX.Element => {
+	const editorStore = 'core/editor';
 	const [ headline, setHeadline ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { editPost, savePost } = useDispatch( editorStore ) as any;
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
-	const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
-		select( 'core/editor' );
+	const { postId, postContent, postHeadline, notices } = useSelect(
+		( select ) => {
+			const { getNotices } = select( noticesStore );
+			const {
+				getCurrentPostId,
+				getEditedPostContent,
+				getEditedPostAttribute,
+			} = select( editorStore ) as selectProps;
 
-	const content = getEditedPostContent();
-	const notices = useSelect(
-		( use ) => use( noticesStore ).getNotices(),
+			return {
+				postId: getCurrentPostId(),
+				postContent: getEditedPostContent(),
+				postHeadline: getEditedPostAttribute( 'meta' )?.apbe_headline,
+				notices: getNotices(),
+			};
+		},
 		[]
 	);
 
 	useEffect( () => {
-		setHeadline( getEditedPostAttribute( 'meta' ).apbe_headline );
-	}, [ getEditedPostAttribute ] );
+		setHeadline( postHeadline );
+	}, [ postHeadline ] );
 
 	/**
 	 * This function fires when the user clicks
@@ -53,8 +70,8 @@ const Headline = (): JSX.Element => {
 				path: '/ai-plus-block-editor/v1/sidebar',
 				method: 'POST',
 				data: {
-					id: getCurrentPostId(),
-					text: content.text || content,
+					id: postId,
+					text: postContent?.text || postContent,
 					feature: 'headline',
 				},
 			} );

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -8,7 +8,8 @@ import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 
-import { selectProps } from '../types';
+import { selectProps } from '../utils/types';
+import { editorStore } from '../utils/store';
 
 /**
  * Headline.
@@ -21,7 +22,6 @@ import { selectProps } from '../types';
  * @return {JSX.Element} Headline.
  */
 const Headline = (): JSX.Element => {
-	const editorStore = 'core/editor';
 	const [ headline, setHeadline ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const { editPost, savePost } = useDispatch( editorStore ) as any;

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -8,11 +8,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 
-interface selectProps {
-	getCurrentPostId: () => number;
-	getEditedPostContent: () => any;
-	getEditedPostAttribute: ( attribute: string ) => any;
-}
+import { selectProps } from '../types';
 
 /**
  * Headline.

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -8,11 +8,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 
-interface selectProps {
-	getCurrentPostId: () => number;
-	getEditedPostContent: () => any;
-	getEditedPostAttribute: ( attribute: string ) => any;
-}
+import { selectProps } from '../types';
 
 /**
  * SEO.

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -8,7 +8,8 @@ import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 
-import { selectProps } from '../types';
+import { selectProps } from '../utils/types';
+import { editorStore } from '../utils/store';
 
 /**
  * SEO.
@@ -21,7 +22,6 @@ import { selectProps } from '../types';
  * @return {JSX.Element} SEO Keywords.
  */
 const SEO = (): JSX.Element => {
-	const editorStore = 'core/editor';
 	const [ keywords, setKeywords ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const { editPost, savePost } = useDispatch( editorStore ) as any;

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -3,10 +3,16 @@ import { check } from '@wordpress/icons';
 import { useState, useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button, TextareaControl, Icon } from '@wordpress/components';
-import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
+
+interface selectProps {
+	getCurrentPostId: () => number;
+	getEditedPostContent: () => any;
+	getEditedPostAttribute: ( attribute: string ) => any;
+}
 
 /**
  * SEO.
@@ -19,22 +25,34 @@ import Toast from '../components/Toast';
  * @return {JSX.Element} SEO Keywords.
  */
 const SEO = (): JSX.Element => {
+	const editorStore = 'core/editor';
 	const [ keywords, setKeywords ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { editPost, savePost } = useDispatch( editorStore ) as any;
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
-	const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
-		select( 'core/editor' );
+	const { postId, postContent, postKeywords, notices } = useSelect(
+		( select ) => {
+			const { getNotices } = select( noticesStore );
+			const {
+				getCurrentPostId,
+				getEditedPostContent,
+				getEditedPostAttribute,
+			} = select( editorStore ) as selectProps;
 
-	const content = getEditedPostContent();
-	const notices = useSelect(
-		( use ) => use( noticesStore ).getNotices(),
+			return {
+				postId: getCurrentPostId(),
+				postContent: getEditedPostContent(),
+				postKeywords:
+					getEditedPostAttribute( 'meta' )?.apbe_seo_keywords,
+				notices: getNotices(),
+			};
+		},
 		[]
 	);
 
 	useEffect( () => {
-		setKeywords( getEditedPostAttribute( 'meta' ).apbe_seo_keywords );
-	}, [ getEditedPostAttribute ] );
+		setKeywords( postKeywords );
+	}, [ postKeywords ] );
 
 	/**
 	 * This function fires when the user clicks
@@ -53,8 +71,8 @@ const SEO = (): JSX.Element => {
 				path: '/ai-plus-block-editor/v1/sidebar',
 				method: 'POST',
 				data: {
-					id: getCurrentPostId(),
-					text: content.text || content,
+					id: postId,
+					text: postContent?.text || postContent,
 					feature: 'keywords',
 				},
 			} );

--- a/src/components/Slug.tsx
+++ b/src/components/Slug.tsx
@@ -3,10 +3,12 @@ import { check } from '@wordpress/icons';
 import { useState, useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button, TextControl, Icon } from '@wordpress/components';
-import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
+
+import { selectProps } from '../types';
 
 /**
  * Slug.
@@ -19,22 +21,33 @@ import Toast from '../components/Toast';
  * @return {JSX.Element} Slug.
  */
 const Slug = (): JSX.Element => {
+	const editorStore = 'core/editor';
 	const [ slug, setSlug ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { editPost, savePost } = useDispatch( editorStore ) as any;
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
-	const { getCurrentPostId, getEditedPostContent, getEditedPostAttribute } =
-		select( 'core/editor' );
+	const { postId, postContent, postSlug, notices } = useSelect(
+		( select ) => {
+			const { getNotices } = select( noticesStore );
+			const {
+				getCurrentPostId,
+				getEditedPostContent,
+				getEditedPostAttribute,
+			} = select( editorStore ) as selectProps;
 
-	const content = getEditedPostContent();
-	const notices = useSelect(
-		( use ) => use( noticesStore ).getNotices(),
+			return {
+				postId: getCurrentPostId(),
+				postContent: getEditedPostContent(),
+				postSlug: getEditedPostAttribute( 'meta' )?.apbe_slug,
+				notices: getNotices(),
+			};
+		},
 		[]
 	);
 
 	useEffect( () => {
-		setSlug( getEditedPostAttribute( 'meta' ).apbe_slug );
-	}, [ getEditedPostAttribute ] );
+		setSlug( postSlug );
+	}, [ postSlug ] );
 
 	/**
 	 * This function fires when the user clicks
@@ -53,8 +66,8 @@ const Slug = (): JSX.Element => {
 				path: '/ai-plus-block-editor/v1/sidebar',
 				method: 'POST',
 				data: {
-					id: getCurrentPostId(),
-					text: content.text || content,
+					id: postId,
+					text: postContent?.text || postContent,
 					feature: 'slug',
 				},
 			} );

--- a/src/components/Slug.tsx
+++ b/src/components/Slug.tsx
@@ -8,7 +8,8 @@ import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 
-import { selectProps } from '../types';
+import { selectProps } from '../utils/types';
+import { editorStore } from '../utils/store';
 
 /**
  * Slug.
@@ -21,7 +22,6 @@ import { selectProps } from '../types';
  * @return {JSX.Element} Slug.
  */
 const Slug = (): JSX.Element => {
-	const editorStore = 'core/editor';
 	const [ slug, setSlug ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const { editPost, savePost } = useDispatch( editorStore ) as any;

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -8,7 +8,8 @@ import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 
-import { selectProps } from '../types';
+import { selectProps } from '../utils/types';
+import { editorStore } from '../utils/store';
 
 /**
  * Summary.
@@ -21,7 +22,6 @@ import { selectProps } from '../types';
  * @return {JSX.Element} Summary.
  */
 const Summary = (): JSX.Element => {
-	const editorStore = 'core/editor';
 	const [ summary, setSummary ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const { editPost, savePost } = useDispatch( editorStore ) as any;

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -3,10 +3,12 @@ import { check } from '@wordpress/icons';
 import { useState, useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button, TextareaControl, Icon } from '@wordpress/components';
-import { select, dispatch, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
+
+import { selectProps } from '../types';
 
 /**
  * Summary.
@@ -19,22 +21,33 @@ import Toast from '../components/Toast';
  * @return {JSX.Element} Summary.
  */
 const Summary = (): JSX.Element => {
+	const editorStore = 'core/editor';
 	const [ summary, setSummary ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { editPost, savePost } = dispatch( 'core/editor' ) as any;
+	const { editPost, savePost } = useDispatch( editorStore ) as any;
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
-	const { getCurrentPostId, getEditedPostContent, getEditedPostAttribute } =
-		select( 'core/editor' );
+	const { postId, postContent, postSummary, notices } = useSelect(
+		( select ) => {
+			const { getNotices } = select( noticesStore );
+			const {
+				getCurrentPostId,
+				getEditedPostContent,
+				getEditedPostAttribute,
+			} = select( editorStore ) as selectProps;
 
-	const content = getEditedPostContent();
-	const notices = useSelect(
-		( use ) => use( noticesStore ).getNotices(),
+			return {
+				postId: getCurrentPostId(),
+				postContent: getEditedPostContent(),
+				postSummary: getEditedPostAttribute( 'meta' )?.apbe_summary,
+				notices: getNotices(),
+			};
+		},
 		[]
 	);
 
 	useEffect( () => {
-		setSummary( getEditedPostAttribute( 'meta' ).apbe_summary );
-	}, [ getEditedPostAttribute ] );
+		setSummary( postSummary );
+	}, [ postSummary ] );
 
 	/**
 	 * This function fires when the user clicks
@@ -53,8 +66,8 @@ const Summary = (): JSX.Element => {
 				path: '/ai-plus-block-editor/v1/sidebar',
 				method: 'POST',
 				data: {
-					id: getCurrentPostId(),
-					text: content.text || content,
+					id: postId,
+					text: postContent?.text || postContent,
 					feature: 'summary',
 				},
 			} );

--- a/src/core/AiTone.tsx
+++ b/src/core/AiTone.tsx
@@ -108,6 +108,7 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 			if ( tone ) {
 				getTone( tone );
 			}
+			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [ tone ] );
 
 		return (

--- a/src/core/AiTone.tsx
+++ b/src/core/AiTone.tsx
@@ -11,7 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 import Toast from '../components/Toast';
 import { getBlockControlOptions } from '../utils';
 import { selectProps, selectBlockProps } from '../utils/types';
-import { editorStore, blockEditorStore } from '../utils/store';
+import { editorStore, noticesStore, blockEditorStore } from '../utils/store';
 
 import '../styles/app.scss';
 

--- a/src/core/AiTone.tsx
+++ b/src/core/AiTone.tsx
@@ -65,13 +65,12 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 		 * @return {void}
 		 */
 		const getTone = async ( newTone: string ): Promise< void > => {
+			const { postId, blockId, blockContent } = getToneParams();
+			const { createErrorNotice } = dispatch( noticesStore ) as any;
 			const { updateBlockAttributes } = dispatch(
 				blockEditorStore
 			) as any;
 
-			const { postId, blockId, blockContent } = getToneParams();
-
-			// Display Toast.
 			setIsLoading( true );
 
 			try {
@@ -96,11 +95,12 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 					limit++;
 				}, 5 );
 
-				// Hide Toast.
 				setIsLoading( false );
 			} catch ( e ) {
-				// eslint-disable-next-line no-console
-				console.log( e.message );
+				createErrorNotice( e.message, {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
 			}
 		};
 

--- a/src/core/AiTone.tsx
+++ b/src/core/AiTone.tsx
@@ -116,7 +116,8 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 				<Toast
 					isInEditor={ true }
 					message={ __(
-						'AI is generating text, please hold on for a bit…'
+						'AI is generating text, please hold on for a bit.',
+						'ai-plus-block-editor'
 					) }
 					isLoading={ isLoading }
 				/>

--- a/src/core/AiTone.tsx
+++ b/src/core/AiTone.tsx
@@ -3,18 +3,18 @@ import { __ } from '@wordpress/i18n';
 import { verse } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
 import { BlockControls } from '@wordpress/block-editor';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { select, dispatch } from '@wordpress/data';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 import { ToolbarGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 
 import Toast from '../components/Toast';
 import { getBlockControlOptions } from '../utils';
+import { selectProps, selectBlockProps } from '../utils/types';
+import { editorStore, blockEditorStore } from '../utils/store';
 
 import '../styles/app.scss';
 
-import { selectProps, selectBlockProps } from '../utils/types';
-import { editorStore, blockEditorStore } from '../utils/store';
 /**
  * Filter Blocks with AI.
  *
@@ -35,6 +35,28 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 		const [ isLoading, setIsLoading ] = useState( false );
 
 		/**
+		 * Get Tone Params.
+		 *
+		 * This function retrieves the current post ID,
+		 * selected block ID, and block content.
+		 *
+		 * @since 1.0.0
+		 * @return {Object} Object containing postId, blockId and blockContent.
+		 */
+		const getToneParams = (): any => {
+			const { getCurrentPostId } = select( editorStore ) as selectProps;
+			const { getSelectedBlock, getSelectedBlockClientId } = select(
+				blockEditorStore
+			) as selectBlockProps;
+
+			return {
+				postId: getCurrentPostId(),
+				blockId: getSelectedBlockClientId(),
+				blockContent: getSelectedBlock()?.attributes?.content || '',
+			};
+		};
+
+		/**
 		 * Get AI generated tone.
 		 *
 		 * @since 1.0.0
@@ -43,23 +65,11 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 		 * @return {void}
 		 */
 		const getTone = async ( newTone: string ): Promise< void > => {
-			const { postId, blockId, blockContent } = useSelect( ( select ) => {
-				const { getCurrentPostId } = select(
-					editorStore
-				) as selectProps;
-				const { getSelectedBlock, getSelectedBlockClientId } = select(
-					blockEditorStore
-				) as selectBlockProps;
-
-				return {
-					postId: getCurrentPostId(),
-					blockId: getSelectedBlockClientId(),
-					blockContent: getSelectedBlock()?.attributes?.content || '',
-				};
-			}, [] );
-			const { updateBlockAttributes } = useDispatch(
+			const { updateBlockAttributes } = dispatch(
 				blockEditorStore
 			) as any;
+
+			const { postId, blockId, blockContent } = getToneParams();
 
 			// Display Toast.
 			setIsLoading( true );

--- a/src/core/AiTone.tsx
+++ b/src/core/AiTone.tsx
@@ -40,7 +40,7 @@ export const filterBlockTypesWithAI = ( settings: any ): object => {
 		 * This function retrieves the current post ID,
 		 * selected block ID, and block content.
 		 *
-		 * @since 1.0.0
+		 * @since 1.4.0
 		 * @return {Object} Object containing postId, blockId and blockContent.
 		 */
 		const getToneParams = (): any => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export interface selectProps {
+	getCurrentPostId: () => number;
+	getEditedPostContent: () => any;
+	getEditedPostAttribute: ( attribute: string ) => any;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,0 @@
-export interface selectProps {
-	getCurrentPostId: () => number;
-	getEditedPostContent: () => any;
-	getEditedPostAttribute: ( attribute: string ) => any;
-}

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,2 +1,3 @@
 export const editorStore = 'core/editor';
+export const noticesStore = 'core/notices';
 export const blockEditorStore = 'core/block-editor';

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,0 +1,2 @@
+export const editorStore = 'core/editor';
+export const blockEditorStore = 'core/block-editor';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,12 @@
+export interface selectProps {
+	getCurrentPostId: () => number;
+	getEditedPostContent: () => any;
+	getEditedPostAttribute: ( attribute: string ) => any;
+}
+
+export interface selectBlockProps {
+	getSelectedBlock: () => any;
+	getSelectedBlockClientId: () => string;
+	getBlockAttributes: ( clientId: string ) => any;
+	getBlock: ( clientId: string ) => any;
+}

--- a/tests/js/Headline.test.tsx
+++ b/tests/js/Headline.test.tsx
@@ -2,10 +2,21 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
+import { useSelect, useDispatch } from '@wordpress/data';
+
 import Headline from '../../src/components/Headline';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: jest.fn( ( arg ) => arg ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -18,9 +29,11 @@ jest.mock( '@wordpress/components', () => ( {
 			</>
 		);
 	} ),
+
 	Icon: jest.fn( () => {
 		return <>Icon</>;
 	} ),
+
 	TextareaControl: jest.fn(
 		( { rows, value, onChange, __nextHasNoMarginBottom = true } ) => {
 			return (
@@ -38,39 +51,27 @@ jest.mock( '@wordpress/components', () => ( {
 	),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	useDispatch: jest.fn( () => ( {
-		removeNotice: jest.fn(),
-	} ) ),
-	dispatch: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					editPost: jest.fn(),
-			  }
-			: {}
-	),
-	select: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					savePost: jest.fn(),
-					getCurrentPostId: jest.fn(),
-					getEditedPostContent: jest.fn(),
-					getEditedPostAttribute: jest.fn( ( attribute ) =>
-						attribute === 'meta'
-							? {
-									apbe_headline: 'AI generated headline...',
-							  }
-							: {}
-					),
-			  }
-			: {}
-	),
-	createReduxStore: jest.fn(),
-	register: jest.fn(),
-} ) );
-
 describe( 'Headline', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockReturnValue( {
+			postId: 1,
+			postContent: 'Hello World',
+			postHeadline: 'AI generated headline...',
+			notices: [],
+		} );
+
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			editPost: jest.fn(),
+			savePost: jest.fn(),
+			removeNotice: jest.fn(),
+			createErrorNotice: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'renders the Headline textarea and 2 buttons', () => {
 		const { container } = render( <Headline /> );
 

--- a/tests/js/SEO.test.tsx
+++ b/tests/js/SEO.test.tsx
@@ -2,10 +2,21 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
+import { useSelect, useDispatch } from '@wordpress/data';
+
 import SEO from '../../src/components/SEO';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: jest.fn( ( arg ) => arg ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -18,9 +29,11 @@ jest.mock( '@wordpress/components', () => ( {
 			</>
 		);
 	} ),
+
 	Icon: jest.fn( () => {
 		return <>Icon</>;
 	} ),
+
 	TextareaControl: jest.fn(
 		( { rows, value, onChange, __nextHasNoMarginBottom = true } ) => {
 			return (
@@ -38,39 +51,27 @@ jest.mock( '@wordpress/components', () => ( {
 	),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	useDispatch: jest.fn( () => ( {
-		removeNotice: jest.fn(),
-	} ) ),
-	dispatch: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					editPost: jest.fn(),
-			  }
-			: {}
-	),
-	select: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					savePost: jest.fn(),
-					getCurrentPostId: jest.fn(),
-					getEditedPostContent: jest.fn(),
-					getEditedPostAttribute: jest.fn( ( attribute ) =>
-						attribute === 'meta'
-							? {
-									apbe_seo_keywords: 'AI generated SEO...',
-							  }
-							: {}
-					),
-			  }
-			: {}
-	),
-	createReduxStore: jest.fn(),
-	register: jest.fn(),
-} ) );
-
 describe( 'SEO', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockReturnValue( {
+			postId: 1,
+			postContent: 'Hello World',
+			postKeywords: 'AI generated SEO...',
+			notices: [],
+		} );
+
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			editPost: jest.fn(),
+			savePost: jest.fn(),
+			removeNotice: jest.fn(),
+			createErrorNotice: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'renders the SEO textarea and 2 buttons', () => {
 		const { container } = render( <SEO /> );
 

--- a/tests/js/Slug.test.tsx
+++ b/tests/js/Slug.test.tsx
@@ -2,10 +2,21 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
+import { useSelect, useDispatch } from '@wordpress/data';
+
 import Slug from '../../src/components/Slug';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: jest.fn( ( arg ) => arg ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -18,9 +29,11 @@ jest.mock( '@wordpress/components', () => ( {
 			</>
 		);
 	} ),
+
 	Icon: jest.fn( () => {
 		return <>Icon</>;
 	} ),
+
 	TextareaControl: jest.fn(
 		( { rows, value, onChange, __nextHasNoMarginBottom = true } ) => {
 			return (
@@ -36,6 +49,7 @@ jest.mock( '@wordpress/components', () => ( {
 			);
 		}
 	),
+
 	TextControl: jest.fn(
 		( {
 			placeholder,
@@ -58,39 +72,27 @@ jest.mock( '@wordpress/components', () => ( {
 	),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	useDispatch: jest.fn( () => ( {
-		removeNotice: jest.fn(),
-	} ) ),
-	dispatch: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					editPost: jest.fn(),
-			  }
-			: {}
-	),
-	select: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					savePost: jest.fn(),
-					getCurrentPostId: jest.fn(),
-					getEditedPostContent: jest.fn(),
-					getEditedPostAttribute: jest.fn( ( attribute ) =>
-						attribute === 'meta'
-							? {
-									apbe_slug: 'ai-generated-slug',
-							  }
-							: {}
-					),
-			  }
-			: {}
-	),
-	createReduxStore: jest.fn(),
-	register: jest.fn(),
-} ) );
-
 describe( 'Slug', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockReturnValue( {
+			postId: 1,
+			postContent: 'Hello World',
+			postSlug: 'ai-generated-slug',
+			notices: [],
+		} );
+
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			editPost: jest.fn(),
+			savePost: jest.fn(),
+			removeNotice: jest.fn(),
+			createErrorNotice: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'renders the Slug text input and 2 buttons', () => {
 		const { container } = render( <Slug /> );
 

--- a/tests/js/Summary.test.tsx
+++ b/tests/js/Summary.test.tsx
@@ -2,10 +2,21 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
+import { useSelect, useDispatch } from '@wordpress/data';
+
 import Summary from '../../src/components/Summary';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: jest.fn( ( arg ) => arg ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -18,9 +29,11 @@ jest.mock( '@wordpress/components', () => ( {
 			</>
 		);
 	} ),
+
 	Icon: jest.fn( () => {
 		return <>Icon</>;
 	} ),
+
 	TextareaControl: jest.fn(
 		( { rows, value, onChange, __nextHasNoMarginBottom = true } ) => {
 			return (
@@ -38,39 +51,26 @@ jest.mock( '@wordpress/components', () => ( {
 	),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	useDispatch: jest.fn( () => ( {
-		removeNotice: jest.fn(),
-	} ) ),
-	dispatch: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					editPost: jest.fn(),
-			  }
-			: {}
-	),
-	select: jest.fn( ( store ) =>
-		store === 'core/editor'
-			? {
-					savePost: jest.fn(),
-					getCurrentPostId: jest.fn(),
-					getEditedPostContent: jest.fn(),
-					getEditedPostAttribute: jest.fn( ( attribute ) =>
-						attribute === 'meta'
-							? {
-									apbe_summary: 'AI generated Summary...',
-							  }
-							: {}
-					),
-			  }
-			: {}
-	),
-	createReduxStore: jest.fn(),
-	register: jest.fn(),
-} ) );
-
 describe( 'Summary', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockReturnValue( {
+			postId: 1,
+			postContent: 'Hello World',
+			postSummary: 'AI generated Summary...',
+			notices: [],
+		} );
+
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			editPost: jest.fn(),
+			savePost: jest.fn(),
+			removeNotice: jest.fn(),
+			createErrorNotice: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
 	it( 'renders the Summary textarea and 2 buttons', () => {
 		const { container } = render( <Summary /> );
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/15).

## Description / Background Context

We need to refactor the sidebar components to adopt the useSelect & useDispatch hooks for implementation.

```js
const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent } =
	select( 'core/editor' );

const content = getEditedPostContent();
const notices = useSelect(
	( use ) => use( noticesStore ).getNotices(),
	[]
);

useEffect( () => {
	setHeadline( getEditedPostAttribute( 'meta' ).apbe_headline );
}, [ getEditedPostAttribute ] );
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Open a new article or post.
4. Test out the AI sidebar features (headline, slug, summary, SEO keywords).
5. All features should work with no regressions.

<img width="304" alt="Screenshot 2025-04-19 at 02 05 22" src="https://github.com/user-attachments/assets/10740197-6169-4129-aec5-76ae0c877777" />