### PR TITLE
Feat: Add AI Provider Switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,50 @@ public function custom_route( $rest_routes ) {
 - rest_routes _`{array}`_ By default this will be an array containing the plugin's REST routes.
 <br/>
 
+#### `apbe_form_fields`
+
+This custom hook (filter) provides the ability to add custom fields to the Admin options page like so:
+
+```php
+add_filter( 'apbe_form_fields', [ $this, 'custom_form_fields' ] );
+
+public function custom_form_fields( $fields ): array {
+    $fields = wp_parse_args(
+        [
+            'custom_group'  => [
+                'label'    => 'Custom Heading',
+                'controls' => [
+                    'custom_option_1' => [
+                        'control' => 'text',
+                        'label'   => 'My Custom Option 1',
+                        'summary' => 'Enable this option to save my custom option 1.',
+                    ],
+                    'custom_option_2' => [
+                        'control' => 'select',
+                        'label'   => 'My Custom Option 2',
+                        'summary' => 'Enable this option to save my custom option 2.',
+                        'options' => [],
+                    ],
+                    'custom_option_3' => [
+                        'control' => 'checkbox',
+                        'label'   => 'My Custom Option 3',
+                        'summary' => 'Enable this option to save my custom option 3.',
+                    ],
+                ],
+            ],
+        ],
+        $fields
+    );
+
+    return (array) $fields;
+}
+```
+
+**Parameters**
+
+- fields _`{array}`_ By default this will be an associative array containing key, value options of each field option.
+<br/>
+
 ### JS Hooks
 
 #### `apbe.allowedBlocks`

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -132,10 +132,9 @@ class Options {
 						'label'   => esc_html__( 'AI Provider', 'ai-plus-block-editor' ),
 						'summary' => 'e.g. Open AI (Chat GPT)',
 						'options' => [
-							'OpenAI'    => 'Open AI',
-							'Google'    => 'Google',
-							'Microsoft' => 'Microsoft',
-							'Facebook'  => 'Facebook',
+							'OpenAI'   => 'ChatGPT',
+							'Gemini'   => 'Gemini',
+							'DeepSeek' => 'DeepSeek',
 						],
 					],
 				],

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -11,6 +11,7 @@
 namespace AiPlusBlockEditor\Providers;
 
 use Orhanerday\OpenAi\OpenAi as ChatGPT;
+use AiPlusBlockEditor\Admin\Options;
 use AiPlusBlockEditor\Interfaces\Provider;
 
 class OpenAI implements Provider {
@@ -52,7 +53,7 @@ class OpenAI implements Provider {
 	 * @return string|\WP_Error
 	 */
 	public function run( $payload ) {
-		$ai_keys = get_option( 'ai_plus_block_editor', [] )['open_ai_token'] ?? '';
+		$ai_keys = get_option( Options::get_page_option(), [] )['open_ai_token'] ?? '';
 		$payload = wp_parse_args( [ 'role' => 'user' ], $payload );
 
 		try {

--- a/inc/Routes/Switcher.php
+++ b/inc/Routes/Switcher.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Switcher Route.
+ *
+ * This route is responsible for updating the
+ * AI Provider.
+ *
+ * @package AiPlusBlockEditor
+ */
+
+namespace AiPlusBlockEditor\Routes;
+
+use AiPlusBlockEditor\Core\AI;
+use AiPlusBlockEditor\Admin\Options;
+use AiPlusBlockEditor\Abstracts\Route;
+use AiPlusBlockEditor\Interfaces\Router;
+
+/**
+ * Switcher class.
+ */
+class Switcher extends Route implements Router {
+	/**
+	 * Get, Post, Put, Patch, Delete.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @var string
+	 */
+	public string $method = 'POST';
+
+	/**
+	 * WP REST Endpoint e.g. /wp-json/ai-plus-block-editor/v1/switcher.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @var string
+	 */
+	public string $endpoint = '/switcher';
+
+	/**
+	 * WP_REST_Request object.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @var \WP_REST_Request
+	 */
+	public \WP_REST_Request $request;
+
+	/**
+	 * Response Callback.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function response() {
+		$args = $this->request->get_json_params();
+
+		if ( empty( $args['provider'] ?? '' ) ) {
+			return $this->get_400_response(
+				sprintf(
+					'API Request does not contain a valid AI provider. Provider: %s',
+					$args['provider'] ?? ''
+				)
+			);
+		}
+
+		update_option(
+			Options::get_page_option(),
+			wp_parse_args(
+				[
+					'ai_provider' => sanitize_text_field( $args['provider'] ),
+				],
+				get_option( Options::get_page_option(), [] )
+			)
+		);
+
+		return rest_ensure_response(
+			[
+				'message'  => sprintf(
+					'AI Provider switched successfully to %s',
+					$args['provider']
+				),
+				'provider' => get_option( Options::get_page_option(), [] )['provider'] ?? '',
+			]
+		);
+	}
+}

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -10,6 +10,7 @@
 
 namespace AiPlusBlockEditor\Services;
 
+use AiPlusBlockEditor\Admin\Options;
 use AiPlusBlockEditor\Abstracts\Service;
 use AiPlusBlockEditor\Interfaces\Kernel;
 
@@ -35,7 +36,7 @@ class Boot extends Service implements Kernel {
 	 */
 	public function register_scripts() {
 		wp_enqueue_script(
-			'ai-plus-block-editor',
+			Options::get_page_slug(),
 			plugins_url( 'ai-plus-block-editor/dist/app.js' ),
 			[
 				'wp-i18n',
@@ -53,8 +54,8 @@ class Boot extends Service implements Kernel {
 		);
 
 		wp_set_script_translations(
-			'ai-plus-block-editor',
-			'ai-plus-block-editor',
+			Options::get_page_slug(),
+			Options::get_page_slug(),
 			plugin_dir_path( __FILE__ ) . '../../languages'
 		);
 	}
@@ -68,7 +69,7 @@ class Boot extends Service implements Kernel {
 	 */
 	public function register_translation() {
 		load_plugin_textdomain(
-			'ai-plus-block-editor',
+			Options::get_page_slug(),
 			false,
 			dirname( plugin_basename( __FILE__ ) ) . '/../../languages'
 		);

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -49,7 +49,7 @@ class Boot extends Service implements Kernel {
 				'wp-plugins',
 				'wp-edit-post',
 			],
-			'1.3.0',
+			'1.5.0',
 			false,
 		);
 

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -53,6 +53,14 @@ class Boot extends Service implements Kernel {
 			false,
 		);
 
+		wp_localize_script(
+			Options::get_page_slug(),
+			'apbe',
+			[
+				'provider' => get_option( Options::get_page_option(), [] )['ai_provider'] ?? '',
+			]
+		);
+
 		wp_set_script_translations(
 			Options::get_page_slug(),
 			Options::get_page_slug(),

--- a/inc/Services/Routes.php
+++ b/inc/Services/Routes.php
@@ -13,6 +13,7 @@ namespace AiPlusBlockEditor\Services;
 
 use AiPlusBlockEditor\Routes\Tone;
 use AiPlusBlockEditor\Routes\SideBar;
+use AiPlusBlockEditor\Routes\Switcher;
 use AiPlusBlockEditor\Abstracts\Service;
 use AiPlusBlockEditor\Interfaces\Kernel;
 
@@ -37,6 +38,7 @@ class Routes extends Service implements Kernel {
 		$this->routes = [
 			Tone::class,
 			SideBar::class,
+			Switcher::class,
 		];
 	}
 

--- a/src/components/Switcher.tsx
+++ b/src/components/Switcher.tsx
@@ -1,0 +1,88 @@
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Switcher.
+ *
+ * This Component handles the switching of AI providers,
+ * for e.g. Open AI -> Gemini and so on.
+ *
+ * @since 1.5.0
+ *
+ * @return {JSX.Element} Switcher.
+ */
+const Switcher = (): JSX.Element => {
+	const { createNotice } = useDispatch( noticesStore );
+	const [ provider, setProvider ] = useState< string >( apbe.provider || '' );
+
+	const handleChange = async ( value: string ) => {
+		setProvider( value );
+
+		try {
+			const response: any = await apiFetch( {
+				path: '/ai-plus-block-editor/v1/switcher',
+				method: 'POST',
+				data: {
+					provider: value,
+				},
+			} );
+
+			createNotice(
+				'success',
+				sprintf(
+					// translators: %s: The snackbar message.
+					__( 'Success! %s', 'ai-plus-block-editor' ),
+					response.message
+				),
+				{
+					isDismissible: true,
+					id: 'apbe-success',
+					type: 'snackbar',
+				}
+			);
+		} catch ( e ) {
+			createNotice(
+				'error',
+				sprintf(
+					// translators: %s: The snackbar message.
+					__( 'Error! %s', 'ai-plus-block-editor' ),
+					e.message
+				),
+				{
+					isDismissible: true,
+					id: 'apbe-error',
+					type: 'snackbar',
+				}
+			);
+		}
+	};
+
+	return (
+		<>
+			<p>
+				<strong>
+					{ __( 'Switch AI Provider', 'ai-plus-block-editor' ) }
+				</strong>
+			</p>
+			<SelectControl
+				label={ null }
+				value={ provider }
+				options={ [
+					{ label: 'ChatGPT', value: 'OpenAI' },
+					{ label: 'Gemini', value: 'Gemini' },
+					{ label: 'DeepSeek', value: 'DeepSeek' },
+				] }
+				onChange={ handleChange }
+				id="switcher"
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+		</>
+	);
+};
+
+export default Switcher;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,7 @@
+import SEO from '../components/SEO';
+import Slug from '../components/Slug';
+import Summary from '../components/Summary';
+import Headline from '../components/Headline';
+import Switcher from '../components/Switcher';
+
+export { SEO, Slug, Summary, Headline, Switcher };

--- a/src/core/AiSideBar.tsx
+++ b/src/core/AiSideBar.tsx
@@ -5,10 +5,7 @@ import { PanelBody } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 
-import SEO from '../components/SEO';
-import Slug from '../components/Slug';
-import Summary from '../components/Summary';
-import Headline from '../components/Headline';
+import { SEO, Slug, Summary, Headline, Switcher } from '../components';
 
 import '../styles/app.scss';
 
@@ -36,6 +33,9 @@ const AiSideBar = (): JSX.Element => {
 				<PanelBody>
 					<div className="apbe-sidebar">
 						<ul>
+							<li>
+								<Switcher />
+							</li>
 							<li>
 								<Headline />
 							</li>

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  var apbe: {
+    provider: string;
+  };
+}
+
+export {};

--- a/tests/js/Switcher.test.tsx
+++ b/tests/js/Switcher.test.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { useDispatch } from '@wordpress/data';
+import Switcher from '../../src/components/Switcher';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: jest.fn( ( arg ) => arg ),
+	sprintf: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	SelectControl: jest.fn( ( { label, value, options, onChange, id } ) => {
+		return (
+			<>
+				<p>{ label }</p>
+				<select
+					onChange={ ( e ) => {
+						const selectedText =
+							e.target.options[ e.target.selectedIndex ].text;
+						onChange( selectedText );
+					} }
+					value={ value }
+					data-testid={ id }
+				>
+					{ options.map(
+						(
+							item: { label: string; value: string },
+							index: number
+						) => {
+							return (
+								<option key={ index } value={ item.value }>
+									{ item.label }
+								</option>
+							);
+						}
+					) }
+				</select>
+			</>
+		);
+	} ),
+} ) );
+
+describe( 'Switcher', () => {
+	beforeEach( () => {
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			createNotice: jest.fn(),
+		} );
+
+		( window as any ).apbe = {
+			provider: 'OpenAI',
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders Switcher component', () => {
+		const { container, getByText, getByRole } = render( <Switcher /> );
+
+		expect( container ).toMatchSnapshot();
+
+		expect( getByText( 'Switch AI Provider' ) ).toBeVisible();
+		expect( getByRole( 'combobox' ) ).toBeVisible();
+		expect( getByText( 'ChatGPT' ) ).toBeVisible();
+		expect( getByText( 'Gemini' ) ).toBeVisible();
+		expect( getByText( 'DeepSeek' ) ).toBeVisible();
+	} );
+
+	it( 'makes an API call request on selection change', () => {
+		const mockCreateNotice = jest.fn();
+
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			createNotice: mockCreateNotice,
+		} );
+
+		const { getByTestId } = render( <Switcher /> );
+
+		const select = getByTestId( 'switcher' );
+		fireEvent.change( select, { target: { value: 'Gemini' } } );
+
+		expect( useDispatch ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/tests/js/__snapshots__/Switcher.test.tsx.snap
+++ b/tests/js/__snapshots__/Switcher.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Switcher renders Switcher component 1`] = `
+<div>
+  <p>
+    <strong>
+      Switch AI Provider
+    </strong>
+  </p>
+  <p />
+  <select
+    data-testid="switcher"
+  >
+    <option
+      value="OpenAI"
+    >
+      ChatGPT
+    </option>
+    <option
+      value="Gemini"
+    >
+      Gemini
+    </option>
+    <option
+      value="DeepSeek"
+    >
+      DeepSeek
+    </option>
+  </select>
+</div>
+`;

--- a/tests/php/Admin/OptionsTest.php
+++ b/tests/php/Admin/OptionsTest.php
@@ -115,10 +115,9 @@ class OptionsTest extends TestCase {
 							'label'   => 'AI Provider',
 							'summary' => 'e.g. Open AI (Chat GPT)',
 							'options' => [
-								'OpenAI'    => 'Open AI',
-								'Google'    => 'Google',
-								'Microsoft' => 'Microsoft',
-								'Facebook'  => 'Facebook',
+								'OpenAI'   => 'ChatGPT',
+								'Gemini'   => 'Gemini',
+								'DeepSeek' => 'DeepSeek',
 							],
 						],
 					],

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -89,6 +89,20 @@ class OpenAITest extends TestCase {
 				]
 			);
 
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
 		\WP_Mock::userFunction( 'wp_parse_args' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {

--- a/tests/php/Routes/SwitcherTest.php
+++ b/tests/php/Routes/SwitcherTest.php
@@ -10,7 +10,6 @@ use AiPlusBlockEditor\Routes\Switcher;
 /**
  * @covers \AiPlusBlockEditor\Routes\Switcher::response
  * @covers \AiPlusBlockEditor\Routes\Switcher::get_400_response
- * @covers \AiPlusBlockEditor\Routes\Switcher::get_response
  */
 class SwitcherTest extends TestCase {
 	public Switcher $switcher;

--- a/tests/php/Routes/SwitcherTest.php
+++ b/tests/php/Routes/SwitcherTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace AiPlusBlockEditor\Tests\Routes;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use AiPlusBlockEditor\Core\AI;
+use AiPlusBlockEditor\Routes\Switcher;
+
+/**
+ * @covers \AiPlusBlockEditor\Routes\Switcher::response
+ * @covers \AiPlusBlockEditor\Routes\Switcher::get_400_response
+ * @covers \AiPlusBlockEditor\Routes\Switcher::get_response
+ */
+class SwitcherTest extends TestCase {
+	public Switcher $switcher;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->switcher = new Switcher();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_route_initial_values() {
+		$this->assertSame( $this->switcher->method, 'POST' );
+		$this->assertSame( $this->switcher->endpoint, '/switcher' );
+	}
+
+	public function test_response_bails_out_if_provider_is_empty() {
+		$switcher = Mockery::mock( Switcher::class )->makePartial();
+		$switcher->shouldAllowMockingProtectedMethods();
+
+		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request->shouldAllowMockingProtectedMethods();
+
+		$request->shouldReceive( 'get_json_params' )
+			->andReturn(
+				[
+					'provider' => '',
+				]
+			);
+
+		$switcher->request = $request;
+
+		$this->assertInstanceOf( \WP_Error::class, $switcher->response() );
+		$this->assertConditionsMet();
+	}
+
+	public function test_provider_is_updated_and_returns_rest_response() {
+		$switcher = Mockery::mock( Switcher::class )->makePartial();
+		$switcher->shouldAllowMockingProtectedMethods();
+
+		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request->shouldAllowMockingProtectedMethods();
+
+		$request->shouldReceive( 'get_json_params' )
+			->andReturn(
+				[
+					'provider' => 'Gemini',
+				]
+			);
+
+		$switcher->request = $request;
+
+		\WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'ai_provider'          => 'OpenAI',
+					'open_ai_enable'       => true,
+					'open_ai_token'        => 'afkqy4iew9bf',
+					'google_gemini_enable' => false,
+					'google_gemini_token'  => '',
+				]
+			);
+
+		\WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'update_option' )
+			->with(
+				'ai_plus_block_editor',
+				[
+					'ai_provider'          => 'Gemini',
+					'open_ai_enable'       => true,
+					'open_ai_token'        => 'afkqy4iew9bf',
+					'google_gemini_enable' => false,
+					'google_gemini_token'  => '',
+				]
+			);
+
+		\WP_Mock::userFunction( 'rest_ensure_response' )
+			->andReturnUsing(
+				function ( $arg ) {
+					if ( $arg instanceof \WP_Error ) {
+						return $arg;
+					}
+
+					if ( is_array( $arg ) ) {
+						return Mockery::mock( \WP_REST_Response::class )->makePartial();
+					}
+
+					return null;
+				}
+			);
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $switcher->response() );
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/php/Routes/SwitcherTest.php
+++ b/tests/php/Routes/SwitcherTest.php
@@ -10,6 +10,12 @@ use AiPlusBlockEditor\Routes\Switcher;
 /**
  * @covers \AiPlusBlockEditor\Routes\Switcher::response
  * @covers \AiPlusBlockEditor\Routes\Switcher::get_400_response
+ * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_notice
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_page
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_submit
+ * @covers \AiPlusBlockEditor\Admin\Options::init
  */
 class SwitcherTest extends TestCase {
 	public Switcher $switcher;

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -11,6 +11,12 @@ use AiPlusBlockEditor\Abstracts\Service;
  * @covers \AiPlusBlockEditor\Services\Boot::register
  * @covers \AiPlusBlockEditor\Services\Boot::register_translation
  * @covers \AiPlusBlockEditor\Services\Boot::register_scripts
+ * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_notice
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_page
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_submit
+ * @covers \AiPlusBlockEditor\Admin\Options::init
  */
 class BootTest extends TestCase {
 	public Boot $boot;

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -63,9 +63,33 @@ class BootTest extends TestCase {
 					'wp-plugins',
 					'wp-edit-post',
 				],
-				'1.3.0',
+				'1.5.0',
 				false,
 			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_localize_script' )
+			->andReturn( null );
 
 		\WP_Mock::userFunction( 'wp_set_script_translations' )
 			->with(
@@ -81,6 +105,20 @@ class BootTest extends TestCase {
 
 	public function test_register_translation() {
 		$boot = new \ReflectionClass( Boot::class );
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
 
 		\WP_Mock::userFunction( 'plugin_basename' )
 			->once()

--- a/tests/php/Services/RoutesTest.php
+++ b/tests/php/Services/RoutesTest.php
@@ -6,6 +6,7 @@ use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Routes\Tone;
 use AiPlusBlockEditor\Routes\SideBar;
+use AiPlusBlockEditor\Routes\Switcher;
 use AiPlusBlockEditor\Services\Routes;
 
 /**
@@ -41,6 +42,7 @@ class RoutesTest extends TestCase {
 				[
 					Tone::class,
 					SideBar::class,
+					Switcher::class,
 				]
 			)
 			->reply(


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/22).

## Description / Background Context

At the moment, users have to go the `AI + Block Editor` options page to change the AI provider. This seems like a not-so-good UI experience for something that should be a trivial task. It would help if users could have a way of switching the AI provider right in the Block editor.

<img width="421" alt="Screenshot 2025-06-15 at 17 45 06" src="https://github.com/user-attachments/assets/af10cac4-8d57-41cf-a9ec-4266575fe0a5" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Open a new article or post.
4. Click on the AI + Plus Block Editor icon.
5. Observe that the Switch provider is in place and ready for use.
6. Select any AI provider of your choice.
7. Observe that provider option is changed and is the same as in the plugin settings page.
8. Observe that there are no regressions with previous expected behaviour.

---

https://github.com/user-attachments/assets/7501698e-8199-4ed9-b8c5-ae7269e1092a