### PR TITLE
Feat: Add Social Media Hash tag sidebar feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.5.0
+* Feat: Add AI Provider Switcher.
+* Feat: Add Social Media Hashtags Feature.
+
 # 1.4.0
 * Refactor: Adopt useSelect & useDispatch hooks in sidebar components.
 * Feat: Add new language translations for Italian, Russian, Chinese, Arabic, Hebrew & Croatian.

--- a/inc/Routes/SideBar.php
+++ b/inc/Routes/SideBar.php
@@ -75,6 +75,7 @@ class SideBar extends Route implements Router {
 	 * the custom prompt.
 	 *
 	 * @since 1.1.0
+	 * @since 1.5.0 Add Social prompt.
 	 *
 	 * @return \WP_REST_Response|\WP_Error
 	 */
@@ -100,6 +101,10 @@ class SideBar extends Route implements Router {
 
 			case 'summary':
 				$placeholder = 'Generate an appropriate %s for the following content: %s';
+				break;
+
+			case 'social':
+				$placeholder = 'Generate appropriate %s media trending tags for the following content: %s';
 				break;
 		}
 

--- a/inc/Routes/SideBar.php
+++ b/inc/Routes/SideBar.php
@@ -104,7 +104,7 @@ class SideBar extends Route implements Router {
 				break;
 
 			case 'social':
-				$placeholder = 'Generate appropriate %s media trending tags for the following content: %s';
+				$placeholder = 'Generate appropriate %s media trending hashtags for the following content: %s';
 				break;
 		}
 

--- a/inc/Services/PostMeta.php
+++ b/inc/Services/PostMeta.php
@@ -36,6 +36,7 @@ class PostMeta extends Service implements Kernel {
 			'apbe_seo_keywords',
 			'apbe_slug',
 			'apbe_summary',
+			'apbe_social',
 		];
 	}
 

--- a/src/components/Social.tsx
+++ b/src/components/Social.tsx
@@ -1,0 +1,155 @@
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import { useState, useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { Button, TextareaControl, Icon } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+import Toast from '../components/Toast';
+
+import { selectProps } from '../utils/types';
+import { editorStore } from '../utils/store';
+
+/**
+ * Social.
+ *
+ * This Component returns the Social media
+ * trending hash-tags & keywords.
+ *
+ * @since 1.5.0
+ *
+ * @return {JSX.Element} Social Hashtags.
+ */
+const Social = (): JSX.Element => {
+	const [ social, setSocial ] = useState( '' );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const { editPost, savePost } = useDispatch( editorStore ) as any;
+	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
+	const { postId, postContent, postSocial, notices } = useSelect(
+		( select ) => {
+			const { getNotices } = select( noticesStore );
+			const {
+				getCurrentPostId,
+				getEditedPostContent,
+				getEditedPostAttribute,
+			} = select( editorStore ) as selectProps;
+
+			return {
+				postId: getCurrentPostId(),
+				postContent: getEditedPostContent(),
+				postSocial: getEditedPostAttribute( 'meta' )?.apbe_social,
+				notices: getNotices(),
+			};
+		},
+		[]
+	);
+
+	useEffect( () => {
+		setSocial( postSocial );
+	}, [ postSocial ] );
+
+	/**
+	 * This function fires when the user clicks
+	 * the `Generate` button.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return { void }
+	 */
+	const handleClick = async (): Promise< void > => {
+		notices.forEach( ( notice ) => removeNotice( notice.id ) );
+		setIsLoading( true );
+
+		try {
+			const aiSocial: string = await apiFetch( {
+				path: '/ai-plus-block-editor/v1/sidebar',
+				method: 'POST',
+				data: {
+					id: postId,
+					text: postContent?.text || postContent,
+					feature: 'social',
+				},
+			} );
+
+			/**
+			 * This function returns a promise that resolves
+			 * to the AI generated social media hashtags and keywords
+			 * when the Animation responsible for showing same is completed.
+			 *
+			 * @since 1.5.0
+			 *
+			 * @return { Promise<string> } Animated text.
+			 */
+			const showAnimatedAiText = (): Promise< string > => {
+				let limit = 1;
+
+				return new Promise( ( resolve ) => {
+					const animatedTextInterval = setInterval( () => {
+						if ( aiSocial.length === limit ) {
+							clearInterval( animatedTextInterval );
+							resolve( aiSocial );
+						}
+						setSocial( aiSocial.substring( 0, limit ) );
+						limit++;
+					}, 5 );
+				} );
+			};
+
+			showAnimatedAiText().then( ( newSocial ) => {
+				editPost( { meta: { apbe_social: newSocial } } );
+			} );
+
+			setIsLoading( false );
+		} catch ( e ) {
+			createErrorNotice( e.message );
+			setIsLoading( false );
+		}
+	};
+
+	/**
+	 * This function fires when the user selects
+	 * the AI generated result.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return { void }
+	 */
+	const handleSelection = (): void => {
+		editPost( { meta: { apbe_social: social } } );
+		savePost();
+	};
+
+	return (
+		<>
+			<p>
+				<strong>
+					{ __( 'Social Media Hashtags', 'ai-plus-block-editor' ) }
+				</strong>
+			</p>
+			<TextareaControl
+				rows={ 4 }
+				value={ social }
+				onChange={ ( text ) => setSocial( text ) }
+				__nextHasNoMarginBottom
+			/>
+			<div className="apbe-button-group">
+				<Button variant="primary" onClick={ handleClick }>
+					{ __( 'Generate', 'ai-plus-block-editor' ) }
+				</Button>
+				<Button variant="secondary" onClick={ handleSelection }>
+					<Icon icon={ check } />
+				</Button>
+			</div>
+			<Toast
+				message={ __(
+					'AI is generating text, please hold on for a bit.',
+					'ai-plus-block-editor'
+				) }
+				isLoading={ isLoading }
+			/>
+		</>
+	);
+};
+
+export default Social;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -3,5 +3,6 @@ import Slug from '../components/Slug';
 import Summary from '../components/Summary';
 import Headline from '../components/Headline';
 import Switcher from '../components/Switcher';
+import Social from '../components/Social';
 
-export { SEO, Slug, Summary, Headline, Switcher };
+export { SEO, Slug, Summary, Headline, Switcher, Social };

--- a/src/core/AiSideBar.tsx
+++ b/src/core/AiSideBar.tsx
@@ -5,7 +5,7 @@ import { PanelBody } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 
-import { SEO, Slug, Summary, Headline, Switcher } from '../components';
+import { SEO, Slug, Summary, Headline, Switcher, Social } from '../components';
 
 import '../styles/app.scss';
 
@@ -47,6 +47,9 @@ const AiSideBar = (): JSX.Element => {
 							</li>
 							<li>
 								<Summary />
+							</li>
+							<li>
+								<Social />
 							</li>
 						</ul>
 					</div>

--- a/tests/js/Social.test.tsx
+++ b/tests/js/Social.test.tsx
@@ -1,0 +1,138 @@
+import '@testing-library/jest-dom';
+import { act, render, fireEvent, waitFor } from '@testing-library/react';
+
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+import Social from '../../src/components/Social';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: jest.fn( ( arg ) => arg ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: jest.fn( ( { children, variant, onClick } ) => {
+		return (
+			<>
+				<button className={ variant } onClick={ onClick }>
+					{ children }
+				</button>
+			</>
+		);
+	} ),
+
+	Icon: jest.fn( () => {
+		return <>Icon</>;
+	} ),
+
+	TextareaControl: jest.fn( ( { rows, value, onChange } ) => {
+		return (
+			<textarea
+				rows={ rows }
+				onChange={ ( e ) => onChange( e.target.value ) }
+				value={ value }
+			/>
+		);
+	} ),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'Social', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockReturnValue( {
+			postId: 1,
+			postContent: 'Hello World',
+			postSocial: '#hello, #world',
+			notices: [],
+		} );
+
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			editPost: jest.fn(),
+			savePost: jest.fn(),
+			removeNotice: jest.fn(),
+			createErrorNotice: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders Social component', () => {
+		const { container, getByText, getByRole } = render( <Social /> );
+
+		expect( container ).toMatchSnapshot();
+
+		expect( getByText( '#hello, #world' ) ).toBeInTheDocument();
+		expect( getByText( 'Social Media Hashtags' ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'Icon' } ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'Generate' } ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'Generate' } ) ).toHaveClass(
+			'primary'
+		);
+	} );
+
+	it( 'renders fetched API data from AI LLM', async () => {
+		const mockEditPost = jest.fn();
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			editPost: mockEditPost,
+		} );
+
+		( apiFetch as unknown as jest.Mock ).mockImplementation(
+			jest.fn( () =>
+				Promise.resolve( '#what, #beautiful, #wonderful, #world' )
+			)
+		);
+
+		const { getByText, getByRole } = render( <Social /> );
+
+		expect( getByText( '#hello, #world' ) ).toBeInTheDocument();
+
+		const button = getByRole( 'button', { name: 'Generate' } );
+		await act( async () => {
+			fireEvent.click( button );
+		} );
+
+		await waitFor( () => {
+			expect( mockEditPost ).toHaveBeenCalledTimes( 1 );
+			expect(
+				getByText( '#what, #beautiful, #wonderful, #world' )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders error notice on API fail.', async () => {
+		const mockCreateErrorNotice = jest.fn();
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			createErrorNotice: mockCreateErrorNotice,
+		} );
+
+		( apiFetch as unknown as jest.Mock ).mockRejectedValueOnce(
+			new Error( 'AI LLM down...' )
+		);
+
+		const { getByText, getByRole } = render( <Social /> );
+
+		expect( getByText( '#hello, #world' ) ).toBeInTheDocument();
+
+		const button = getByRole( 'button', { name: 'Generate' } );
+		await act( async () => {
+			fireEvent.click( button );
+		} );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 );
+			expect( getByText( '#hello, #world' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/tests/js/__snapshots__/Social.test.tsx.snap
+++ b/tests/js/__snapshots__/Social.test.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Social renders Social component 1`] = `
+<div>
+  <p>
+    <strong>
+      Social Media Hashtags
+    </strong>
+  </p>
+  <textarea
+    rows="4"
+  >
+    #hello, #world
+  </textarea>
+  <div
+    class="apbe-button-group"
+  >
+    <button
+      class="primary"
+    >
+      Generate
+    </button>
+    <button
+      class="secondary"
+    >
+      Icon
+    </button>
+  </div>
+</div>
+`;

--- a/tests/php/Routes/SideBarTest.php
+++ b/tests/php/Routes/SideBarTest.php
@@ -255,7 +255,7 @@ class SideBarTest extends TestCase {
 
 		\WP_Mock::expectFilter(
 			'apbe_feature_prompt',
-			'Generate appropriate social media trending tags for the following content: Hello World!',
+			'Generate appropriate social media trending hashtags for the following content: Hello World!',
 			'social',
 			'Hello World!'
 		);
@@ -270,7 +270,7 @@ class SideBarTest extends TestCase {
 		$ai->shouldReceive( 'run' )
 			->with(
 				[
-					'content' => 'Generate appropriate social media trending tags for the following content: Hello World!',
+					'content' => 'Generate appropriate social media trending hashtags for the following content: Hello World!',
 				]
 			)
 			->andReturn( '#hello, #world' );

--- a/tests/php/Routes/SideBarTest.php
+++ b/tests/php/Routes/SideBarTest.php
@@ -240,4 +240,46 @@ class SideBarTest extends TestCase {
 		$this->assertSame( $response, 'What a Wonderful World!' );
 		$this->assertConditionsMet();
 	}
+
+	public function test_get_response_passes_with_social_media_hashtag_feature() {
+		$sidebar = Mockery::mock( SideBar::class )->makePartial();
+		$sidebar->shouldAllowMockingProtectedMethods();
+
+		$ai = Mockery::mock( AI::class )->makePartial();
+		$ai->shouldAllowMockingProtectedMethods();
+
+		$sidebar->args = [
+			'feature' => 'social',
+			'text'    => 'Hello World!',
+		];
+
+		\WP_Mock::expectFilter(
+			'apbe_feature_prompt',
+			'Generate appropriate social media trending tags for the following content: Hello World!',
+			'social',
+			'Hello World!'
+		);
+
+		\WP_Mock::userFunction( 'rest_ensure_response' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		$ai->shouldReceive( 'run' )
+			->with(
+				[
+					'content' => 'Generate appropriate social media trending tags for the following content: Hello World!',
+				]
+			)
+			->andReturn( '#hello, #world' );
+
+		$sidebar->ai = $ai;
+
+		$response = $sidebar->get_response();
+
+		$this->assertSame( $response, '#hello, #world' );
+		$this->assertConditionsMet();
+	}
 }

--- a/tests/php/Services/PostMetaTest.php
+++ b/tests/php/Services/PostMetaTest.php
@@ -40,6 +40,7 @@ class PostMetaTest extends TestCase {
 					'apbe_seo_keywords',
 					'apbe_slug',
 					'apbe_summary',
+					'apbe_social',
 				]
 			)
 			->reply(


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/24).

## Description / Background Context

It would be beneficial to introduce a hash-tag, social media option in the sidebar alongside the existing controls.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Open a new article or post.
4. Click on the AI + Plus Block Editor icon.
5. Scroll down to see new Social media hash tag feature.
6. Generate hash tags by clicking on the **Generate** button.
7. Observe that there are no regressions with previous expected behaviour.

---

<img width="352" alt="Screenshot 2025-06-17 at 18 14 49" src="https://github.com/user-attachments/assets/daa5efec-aeb5-49ed-b59d-1d8b447882b6" />