### PR TITLE
Chore: Relocate `apbeMenuBlockOptions` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feat: Add Social Media Hashtags Feature.
 * Fix: Breaking issue with Tone functionality.
 * Test: Fix Unit tests & update snapshots.
+* Chore: Relocate `apbe.blockMenuOptions` hook.
 
 # 1.4.0
 * Refactor: Adopt useSelect & useDispatch hooks in sidebar components.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ addFilter(
 
 **Parameters**
 
-- blockMenuOptions _`{object}`_ List of Block Menu Options.
+- blockMenuOptions _`{Object}`_ List of Block Menu Options.
 <br/>
 
 ---

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ addFilter(
 
 **Parameters**
 
-- blockMenuOptions _`{string[]}`_ List of Block Menu Options.
+- blockMenuOptions _`{object}`_ List of Block Menu Options.
 <br/>
 
 ---

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -9,46 +9,47 @@ type DropdownOption = {
 /**
  * Get Options.
  *
- * This function filters the Block Control Options
+ * This function filters the Block Menu AI Options
  * available when the user selects a block.
  *
  * @since 1.1.0
  *
- * @param {Function} setTone Subscribe to setTone setter method.
+ * @param {Function} getTone Function to get the tone.
  * @return {DropdownOption[]} Dropdown options.
  */
-export const getBlockMenuOptions = ( setTone: Function ): DropdownOption[] => {
+export const getBlockMenuOptions = ( getTone: Function ): DropdownOption[] => {
 	const menu = [];
 
-	const options = {
+	/**
+	 * Filter Menu Options.
+	 *
+	 * By default the passed object should contain
+	 * menu options.
+	 *
+	 * @since 1.1.0
+	 * @since 1.5.0 Pass in menu options before returning menu.
+	 *
+	 * @param {Object} menu Menu options.
+	 * @return {Object}
+	 */
+	const options = applyFilters( 'apbe.blockMenuOptions', {
 		casual: __( 'Use Casual Tone', 'ai-plus-block-editor' ),
 		official: __( 'Use Official Tone', 'ai-plus-block-editor' ),
 		descriptive: __( 'Use Descriptive Tone', 'ai-plus-block-editor' ),
 		narrative: __( 'Use Narrative Tone', 'ai-plus-block-editor' ),
 		aggressive: __( 'Use Aggressive Tone', 'ai-plus-block-editor' ),
-	};
+	} );
 
 	Object.keys( options ).forEach( ( key ) => {
 		menu.push( {
 			title: options[ key ],
 			onClick: () => {
-				setTone( key );
+				getTone( key );
 			},
 		} );
 	} );
 
-	/**
-	 * Filter Menu.
-	 *
-	 * By default the passed option should contain
-	 * menu objects.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param {DropdownOption[]} menu Menu array containing menu objects.
-	 * @return {DropdownOption[]}
-	 */
-	return applyFilters( 'apbe.blockMenuOptions', menu ) as DropdownOption[];
+	return menu;
 };
 
 /**


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/ai-plus-block-editor/issues/34).

## Description / Background Context

This filter appears to be located in the wrong location in the `getBlockMenuOptions` utility. We need to update this to happen before the menu options is returned.

```js
/**
 * Filter Menu.
 *
 * By default the passed option should contain
 * menu objects.
 *
 * @since 1.1.0
 *
 * @param {DropdownOption[]} menu Menu array containing menu objects.
 * @return {DropdownOption[]}
 */
return applyFilters( 'apbe.blockMenuOptions', menu ) as DropdownOption[];
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Create a new article/post and type in a paragraph.
4. Click anywhere on paragraph block to view AI menu options.
5. Select a tone of your choice.
6. Tone feature should work correctly without any regressions.

---

<img width="851" alt="Screenshot 2025-06-18 at 15 16 55" src="https://github.com/user-attachments/assets/b6308c5d-581c-4068-a9a3-ce0f3bb5bbc5" />