### PR TITLE
Chore: Enforce API key check for OpenAI

### DIFF
--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -55,8 +55,8 @@ class OpenAI implements Provider {
 	 * @return ChatGPT
 	 */
 	protected function get_client(): ChatGPT {
-		$ai_keys = get_option( Options::get_page_option(), [] )['open_ai_token'] ?? '';
-		return new ChatGPT( $ai_keys );
+		$api_key = get_option( Options::get_page_option(), [] )['open_ai_token'] ?? '';
+		return new ChatGPT( $api_key );
 	}
 
 	/**
@@ -68,7 +68,24 @@ class OpenAI implements Provider {
 	 * @return string|\WP_Error
 	 */
 	public function run( $payload ) {
-		$ai_keys = get_option( Options::get_page_option(), [] )['open_ai_token'] ?? '';
+		$api_key = get_option( Options::get_page_option(), [] )['open_ai_token'] ?? '';
+
+		if ( empty( $api_key ) ) {
+			return $this->get_json_error(
+				__( 'Missing OpenAI API key.', 'ai-plus-block-editor' )
+			);
+		}
+
+		// Default prompt if not passed.
+		$prompt_text = $payload['content'] ?? '';
+
+		// Validate prompt text.
+		if ( ! is_string( $prompt_text ) || empty( $prompt_text ) ) {
+			return $this->get_json_error(
+				__( 'Invalid prompt text.', 'ai-plus-block-editor' )
+			);
+		}
+
 		$payload = wp_parse_args( [ 'role' => 'user' ], $payload );
 
 		try {

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -98,6 +98,98 @@ class OpenAITest extends TestCase {
 		$this->assertInstanceOf( ChatGPT::class, $open_ai->get_client() );
 	}
 
+	public function test_run_fails_if_missing_api_keys_and_returns_wp_error() {
+		$open_ai = Mockery::mock( OpenAI::class )->makePartial();
+		$open_ai->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'open_ai_token' => '',
+				]
+			);
+
+		$response = $open_ai->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_prompt_text_and_returns_wp_error() {
+		$open_ai = Mockery::mock( OpenAI::class )->makePartial();
+		$open_ai->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'open_ai_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		$response = $open_ai->run(
+			[
+				'content' => '',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 *


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/40).

## Description / Background Context

This PR focuses on enforcing API key check for the OpenAI provider before calling the API.

```php
$api_key = get_option( Options::get_page_option(), [] )['open_ai_token'] ?? '';

if ( empty( $api_key ) ) {
	return $this->get_json_error(
		__( 'Missing OpenAI API key.', 'ai-plus-block-editor' )
	);
}

// Default prompt if not passed.
$prompt_text = $payload['content'] ?? '';

// Validate prompt text.
if ( ! is_string( $prompt_text ) || empty( $prompt_text ) ) {
	return $this->get_json_error(
		__( 'Invalid prompt text.', 'ai-plus-block-editor' )
	);
}
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Remove the OpenAI API keys from the plugin settings page and save.
4. Attempt to generate AI text using the sidebar feature.
5. Observe that error message is thrown correctly in console tab.