### PR TITLE
Feat: Add Google Gemini AI Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,58 @@ public function custom_ai_provider( $ai_provider ) {
 - ai_provider _`{Provider}`_ By default this will be an instance of the Provider interface that MUST contain a `run` method implementation.
 <br/>
 
+#### `apbe_gemini_api_url`
+
+This custom hook (filter) provides the ability to modify the Gemini API endpoint used for generating AI content.
+
+```php
+add_filter( 'apbe_gemini_api_url', [ $this, 'custom_api_url' ], 10, 1 );
+
+public function custom_api_url( $url ) {
+    $project_id  = 'johndoe';
+    $location    = 'virginia-us';
+    $endpoint_id = 'agewcbdkh78hjkf';
+
+    return esc_url( sprintf(
+        'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/%s:generateContent',
+        $project_id,
+        $location,
+        $endpoint_id,
+		) );
+}
+```
+
+**Parameters**
+
+- url _`{string}`_ By default this will be a string containing the API endpoint for the Gemini LLM.
+<br/>
+
+#### `apbe_gemini_args`
+
+This custom hook (filter) provides the ability to modify the Gemini args before it is sent to the LLM.
+
+```php
+add_filter( 'apbe_gemini_args', [ $this, 'custom_args' ], 10, 1 );
+
+public function custom_args( $args ) {
+    return wp_parse_args(
+        [
+            'model'           => 'gemini-2.0-flash',
+            'temperature'     => 1.0,
+            'maxOutputTokens' => 256,
+            'topK'            => 40,
+            'topP'            => 0.95,
+        ],
+        $args
+    )
+}
+```
+
+**Parameters**
+
+- args _`{array}`_ By default this will be an array containing the Gemini default parameters.
+<br/>
+
 #### `apbe_open_ai_args`
 
 This custom hook (filter) provides the ability to modify the OpenAI args before it sent to the LLM.

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -164,7 +164,7 @@ class Options {
 						'summary' => esc_html__( 'Use Google Gemini capabilities in Block Editor', 'ai-plus-block-editor' ),
 					],
 					'google_gemini_token'  => [
-						'control'     => esc_attr( 'text' ),
+						'control'     => esc_attr( 'password' ),
 						'placeholder' => esc_attr( '' ),
 						'label'       => esc_html__( 'API Keys', 'ai-plus-block-editor' ),
 						'summary'     => esc_html__( 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av', 'ai-plus-block-editor' ),

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -11,6 +11,7 @@
 namespace AiPlusBlockEditor\Core;
 
 use AiPlusBlockEditor\Providers\OpenAI;
+use AiPlusBlockEditor\Providers\Gemini;
 use AiPlusBlockEditor\Interfaces\Provider;
 
 class AI implements Provider {
@@ -30,6 +31,10 @@ class AI implements Provider {
 		switch ( $ai_provider ) {
 			case 'OpenAI':
 				$ai_provider = OpenAI::class;
+				break;
+
+			case 'Gemini':
+				$ai_provider = Gemini::class;
 				break;
 		}
 

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -11,49 +11,114 @@
 namespace AiPlusBlockEditor\Providers;
 
 use AiPlusBlockEditor\Interfaces\Provider;
+use AiPlusBlockEditor\Admin\Options;
 
 class Gemini implements Provider {
 	/**
-	 * Gemini API URL.
+	 * Get Default Args.
 	 *
-	 * @since 1.0.0
+	 * @since 1.5.0
 	 *
-	 * @var string
+	 * @return mixed[]
 	 */
-	public string $gemini_url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+	protected function get_default_args(): array {
+		$args = [
+			'model'           => 'gemini-2.0-flash',
+			'temperature'     => 1.0,
+			'maxOutputTokens' => 256,
+			'topK'            => 40,
+			'topP'            => 0.95,
+			'stopSequences'   => [ "\n\n" ],
+		];
+
+		/**
+		 * Filter Gemini default args.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @param mixed[] $args Default args.
+		 * @return mixed[]
+		 */
+		$filtered_args = (array) apply_filters( 'apbe_gemini_args', $args );
+
+		return wp_parse_args( $filtered_args, $args );
+	}
+
+	/**
+	 * Get API URL.
+	 *
+	 * This method returns the Gemini API URL
+	 * endpoint. It can be filtered using the
+	 * 'apbe_gemini_api_url' filter.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return string
+	 */
+	protected function get_api_url(): string {
+		$url = esc_url(
+			sprintf(
+				'https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent',
+				$this->get_default_args()['model'] ?? ''
+			)
+		);
+
+		/**
+		 * Filter Gemini API URL.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @param string $url Gemini API URL.
+		 * @return string
+		 */
+		return apply_filters( 'apbe_gemini_api_url', $url );
+	}
 
 	/**
 	 * Get AI Response.
 	 *
-	 * @since 1.0.0
+	 * @since 1.5.0
 	 *
 	 * @param mixed[] $payload JSON Payload.
 	 * @return string|\WP_Error
 	 */
 	public function run( $payload ) {
-		$options  = get_option( 'ai_plus_block_editor', [] );
-		$api_key  = $options['google_gemini'] ?? '';
+		$api_key = get_option( Options::get_page_option(), [] )['google_gemini_token'] ?? '';
 
 		if ( empty( $api_key ) ) {
-			return $this->get_json_error( 'Missing Gemini API key.' );
+			return $this->get_json_error(
+				__( 'Missing Gemini API key.', 'ai-plus-block-editor' )
+			);
 		}
 
-		// Default prompt if not passed
-		$prompt_text = $payload['text'] ?? 'Say something smart';
+		// Default prompt if not passed.
+		$prompt_text = $payload['content'] ?? '';
 
-		// Gemini-compatible payload
+		// Validate prompt text.
+		if ( ! is_string( $prompt_text ) || empty( $prompt_text ) ) {
+			return $this->get_json_error(
+				__( 'Invalid prompt text.', 'ai-plus-block-editor' )
+			);
+		}
+
+		$args = $this->get_default_args();
+		unset( $args['model'] );
+
+		// Gemini API expects a specific body structure.
 		$body = [
-			'contents' => [
+			'contents'         => [
 				[
+					'role'  => 'user',
 					'parts' => [
 						[ 'text' => $prompt_text ],
 					],
 				],
 			],
+			'generationConfig' => $args,
 		];
 
 		$response = wp_remote_post(
-			add_query_arg( 'key', $api_key, $this->gemini_url ),
+			add_query_arg( 'key', $api_key, $this->get_api_url() ),
 			[
 				'headers' => [
 					'Content-Type' => 'application/json',
@@ -79,7 +144,7 @@ class Gemini implements Provider {
 	/**
 	 * Get JSON Error.
 	 *
-	 * @since 1.0.0
+	 * @since 1.5.0
 	 *
 	 * @param string $message Error Message.
 	 * @return \WP_Error

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Gemini Class.
+ *
+ * This class is responsible for handling
+ * Gemini calls.
+ *
+ * @package AiPlusBlockEditor
+ */
+
+namespace AiPlusBlockEditor\Providers;
+
+use AiPlusBlockEditor\Interfaces\Provider;
+
+class Gemini implements Provider {
+	/**
+	 * Gemini API URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $gemini_url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+
+	/**
+	 * Get AI Response.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed[] $payload JSON Payload.
+	 * @return string|\WP_Error
+	 */
+	public function run( $payload ) {
+		$options  = get_option( 'ai_plus_block_editor', [] );
+		$api_key  = $options['google_gemini'] ?? '';
+
+		if ( empty( $api_key ) ) {
+			return $this->get_json_error( 'Missing Gemini API key.' );
+		}
+
+		// Default prompt if not passed
+		$prompt_text = $payload['text'] ?? 'Say something smart';
+
+		// Gemini-compatible payload
+		$body = [
+			'contents' => [
+				[
+					'parts' => [
+						[ 'text' => $prompt_text ],
+					],
+				],
+			],
+		];
+
+		$response = wp_remote_post(
+			add_query_arg( 'key', $api_key, $this->gemini_url ),
+			[
+				'headers' => [
+					'Content-Type' => 'application/json',
+				],
+				'body'    => wp_json_encode( $body ),
+				'timeout' => 20,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $this->get_json_error( $response->get_error_message() );
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( isset( $data['error'] ) ) {
+			return $this->get_json_error( $data['error']['message'] ?? 'Unknown Gemini API error.' );
+		}
+
+		return $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
+	}
+
+	/**
+	 * Get JSON Error.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $message Error Message.
+	 * @return \WP_Error
+	 */
+	protected function get_json_error( $message ) {
+		return new \WP_Error(
+			'ai-plus-block-editor-json-error',
+			$message,
+			[ 'status' => 500 ]
+		);
+	}
+}

--- a/tests/php/Admin/OptionsTest.php
+++ b/tests/php/Admin/OptionsTest.php
@@ -147,7 +147,7 @@ class OptionsTest extends TestCase {
 							'summary' => 'Use Google Gemini capabilities in Block Editor',
 						],
 						'google_gemini_token'  => [
-							'control'     => 'text',
+							'control'     => 'password',
 							'placeholder' => '',
 							'label'       => 'API Keys',
 							'summary'     => 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av',

--- a/tests/php/Providers/GeminiTest.php
+++ b/tests/php/Providers/GeminiTest.php
@@ -8,6 +8,7 @@ use AiPlusBlockEditor\Providers\Gemini;
 
 /**
  * @covers \AiPlusBlockEditor\Providers\Gemini::run
+ * @covers \AiPlusBlockEditor\Providers\Gemini::get_api_url
  * @covers \AiPlusBlockEditor\Providers\Gemini::get_default_args
  * @covers \AiPlusBlockEditor\Providers\Gemini::get_json_error
  * @covers \AiPlusBlockEditor\Admin\Options::__callStatic

--- a/tests/php/Providers/GeminiTest.php
+++ b/tests/php/Providers/GeminiTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace AiPlusBlockEditor\Tests\Providers;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use AiPlusBlockEditor\Providers\Gemini;
+
+/**
+ * @covers \AiPlusBlockEditor\Providers\Gemini::run
+ * @covers \AiPlusBlockEditor\Providers\Gemini::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\Gemini::get_json_error
+ * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_notice
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_page
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_submit
+ * @covers \AiPlusBlockEditor\Admin\Options::init
+ */
+class GeminiTest extends TestCase {
+	public Gemini $gemini;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->gemini = new Gemini();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_get_default_args() {
+		\WP_Mock::expectFilter(
+			'apbe_gemini_args',
+			[
+				'model'           => 'gemini-2.0-flash',
+				'temperature'     => 1.0,
+				'maxOutputTokens' => 256,
+				'topK'            => 40,
+				'topP'            => 0.95,
+				'stopSequences'   => [ "\n\n" ],
+			]
+		);
+
+		\WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		$reflection = new \ReflectionClass( $this->gemini );
+		$method     = $reflection->getMethod( 'get_default_args' );
+
+		$method->setAccessible( true );
+		$args = $method->invoke( $this->gemini );
+
+		$this->assertSame(
+			$args,
+			[
+				'model'           => 'gemini-2.0-flash',
+				'temperature'     => 1.0,
+				'maxOutputTokens' => 256,
+				'topK'            => 40,
+				'topP'            => 0.95,
+				'stopSequences'   => [ "\n\n" ],
+			]
+		);
+	}
+
+	public function test_get_api_url() {
+		$gemini = Mockery::mock( Gemini::class )->makePartial();
+		$gemini->shouldAllowMockingProtectedMethods();
+
+		$gemini->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model' => 'gemini-2.0-flash',
+				]
+			);
+
+		\WP_Mock::expectFilter(
+			'apbe_gemini_api_url',
+			'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+		);
+
+		\WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		$url = $gemini->get_api_url();
+
+		$this->assertSame( $url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent' );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_api_keys_and_returns_wp_error() {
+		$gemini = Mockery::mock( Gemini::class )->makePartial();
+		$gemini->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'google_gemini_token' => '',
+				]
+			);
+
+		$response = $gemini->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_prompt_text_and_returns_wp_error() {
+		$gemini = Mockery::mock( Gemini::class )->makePartial();
+		$gemini->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'google_gemini_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		$response = $gemini->run(
+			[
+				'content' => '',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run() {
+		$gemini = Mockery::mock( Gemini::class )->makePartial();
+		$gemini->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$gemini->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model'           => 'gemini-2.0-flash',
+					'temperature'     => 1.0,
+					'maxOutputTokens' => 256,
+					'topK'            => 40,
+					'topP'            => 0.95,
+					'stopSequences'   => [ "\n\n" ],
+				]
+			);
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'google_gemini_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		\WP_Mock::userFunction( 'add_query_arg' )
+			->andReturnNull();
+
+		$gemini->shouldReceive( 'get_api_url' )
+		->andReturn( '' );
+
+		\WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn( '{"body":{"candidates":[{"content":{"parts":[{"text":"What a Wonderful World!"}]}}]}}' );
+
+		\WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( '{"candidates":[{"content":{"parts":[{"text":"What a Wonderful World!"}]}}]}' );
+
+		$response = $gemini->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertSame( 'What a Wonderful World!', $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_json_error() {
+		$gemini = Mockery::mock( Gemini::class )->makePartial();
+		$gemini->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$response = $gemini->get_json_error( 'API Error...' );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+}


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/21).

## Description / Background Context

At the moment, we currently have the OpenAI provider in place, which works correctly for users as expected. As a step further, we would like to implement the Google Gemini AI provider to enable users use Gemini as their AI option of choice. For reference pls see [Google Gemini API Keys](https://ai.google.dev/gemini-api/docs/api-key) link.

This PR focuses on implementing this correctly.

<img width="343" alt="Screenshot 2025-06-23 at 02 51 16" src="https://github.com/user-attachments/assets/8270ffbf-8a80-4a9c-8bb6-05612cf5a76f" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Select the Google **Gemini** AI provider.
4. Generate any of the sidebar features (headline, summary...).
5. Observe that it is working correctly.
6. All other features should work correctly as before without any regressions.