### PR TITLE
Feat: Implement DeepSeek AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 * Refactor: Update Components to use WP's snackbar notice.
+* Feat: Implement DeepSeek AI provider.
 
 # 1.5.0
 * Feat: AI Provider Switcher.

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -171,6 +171,22 @@ class Options {
 					],
 				],
 			],
+			'deepseek_options'      => [
+				'heading'  => esc_html__( 'DeepSeek', 'ai-plus-block-editor' ),
+				'controls' => [
+					'deepseek_enable' => [
+						'control' => esc_attr( 'checkbox' ),
+						'label'   => esc_html__( 'Enable DeepSeek', 'ai-plus-block-editor' ),
+						'summary' => esc_html__( 'Use DeepSeek capabilities in Block Editor', 'ai-plus-block-editor' ),
+					],
+					'deepseek_token'  => [
+						'control'     => esc_attr( 'password' ),
+						'placeholder' => esc_attr( '' ),
+						'label'       => esc_html__( 'API Keys', 'ai-plus-block-editor' ),
+						'summary'     => esc_html__( 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av', 'ai-plus-block-editor' ),
+					],
+				],
+			],
 		];
 	}
 

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -12,6 +12,7 @@ namespace AiPlusBlockEditor\Core;
 
 use AiPlusBlockEditor\Providers\OpenAI;
 use AiPlusBlockEditor\Providers\Gemini;
+use AiPlusBlockEditor\Providers\DeepSeek;
 use AiPlusBlockEditor\Interfaces\Provider;
 
 class AI implements Provider {
@@ -35,6 +36,10 @@ class AI implements Provider {
 
 			case 'Gemini':
 				$ai_provider = Gemini::class;
+				break;
+
+			case 'DeepSeek':
+				$ai_provider = DeepSeek::class;
 				break;
 		}
 
@@ -74,6 +79,14 @@ class AI implements Provider {
 	 * @return string|\WP_Error
 	 */
 	public function run( $payload ) {
+		// Sanitize Prompt.
+		$payload['content'] = html_entity_decode(
+			wp_strip_all_tags(
+				apply_filters( 'the_content', $payload['content'] ?? '' ),
+				true
+			)
+		);
+
 		try {
 			return $this->get_provider()->run( $payload );
 		} catch ( \Exception $e ) {

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * DeepSeek Class.
+ *
+ * This class is responsible for handling
+ * DeepSeek calls.
+ *
+ * @package AiPlusBlockEditor
+ */
+
+namespace AiPlusBlockEditor\Providers;
+
+use AiPlusBlockEditor\Interfaces\Provider;
+use AiPlusBlockEditor\Admin\Options;
+
+class DeepSeek implements Provider {
+	/**
+	 * Get Default Args.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return mixed[]
+	 */
+	protected function get_default_args(): array {
+		$args = [
+			'model'             => 'deepseek-chat',
+			'temperature'       => 0.7,
+			'top_p'             => 1,
+			'max_tokens'        => 500,
+			'presence_penalty'  => 0,
+			'frequency_penalty' => 0,
+		];
+
+		/**
+		 * Filter DeepSeek default args.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param mixed[] $args Default args.
+		 * @return mixed[]
+		 */
+		$filtered_args = (array) apply_filters( 'apbe_deepseek_args', $args );
+
+		return wp_parse_args( $filtered_args, $args );
+	}
+
+	/**
+	 * Get API URL.
+	 *
+	 * This method returns the DeepSeek API URL
+	 * endpoint. It can be filtered using the
+	 * 'apbe_deepseek_api_url' filter.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return string
+	 */
+	protected function get_api_url(): string {
+		$url = esc_url( 'https://api.deepseek.com/chat/completions' );
+
+		/**
+		 * Filter DeepSeek API URL.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param string $url DeepSeek API URL.
+		 * @return string
+		 */
+		return apply_filters( 'apbe_deepseek_api_url', $url );
+	}
+
+	/**
+	 * Get AI Response.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param mixed[] $payload JSON Payload.
+	 * @return string|\WP_Error
+	 */
+	public function run( $payload ) {
+		$api_key = get_option( Options::get_page_option(), [] )['deepseek_token'] ?? '';
+
+		if ( empty( $api_key ) ) {
+			return $this->get_json_error(
+				__( 'Missing DeepSeek API key.', 'ai-plus-block-editor' )
+			);
+		}
+
+		// Default prompt if not passed.
+		$prompt_text = $payload['content'] ?? '';
+
+		// Validate prompt text.
+		if ( ! is_string( $prompt_text ) || empty( $prompt_text ) ) {
+			return $this->get_json_error(
+				__( 'Invalid prompt text.', 'ai-plus-block-editor' )
+			);
+		}
+
+		// DeepSeek API expects a specific body structure.
+		$body = wp_parse_args(
+			[
+				'messages' => [
+					[
+						'role'    => 'system',
+						'content' => 'You are a helpful assistant.',
+					],
+					[
+						'role'    => 'user',
+						'content' => $prompt_text,
+					],
+				],
+			],
+			$this->get_default_args()
+		);
+
+		$response = wp_remote_post(
+			$this->get_api_url(),
+			[
+				'headers' => [
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				],
+				'body'    => wp_json_encode( $body, JSON_UNESCAPED_UNICODE ),
+				'timeout' => 20,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $this->get_json_error( $response->get_error_message() );
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		return $data['choices'][0]['message']['content'] ?? '';
+	}
+
+	/**
+	 * Get JSON Error.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $message Error Message.
+	 * @return \WP_Error
+	 */
+	protected function get_json_error( $message ) {
+		return new \WP_Error(
+			'ai-plus-block-editor-json-error',
+			$message,
+			[ 'status' => 500 ]
+		);
+	}
+}

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -123,7 +123,7 @@ class Gemini implements Provider {
 				'headers' => [
 					'Content-Type' => 'application/json',
 				],
-				'body'    => wp_json_encode( $body ),
+				'body'    => wp_json_encode( $body, JSON_UNESCAPED_UNICODE ),
 				'timeout' => 20,
 			]
 		);

--- a/tests/php/Admin/OptionsTest.php
+++ b/tests/php/Admin/OptionsTest.php
@@ -154,6 +154,22 @@ class OptionsTest extends TestCase {
 						],
 					],
 				],
+				'deepseek_options'      => [
+					'heading'  => 'DeepSeek',
+					'controls' => [
+						'deepseek_enable' => [
+							'control' => 'checkbox',
+							'label'   => 'Enable DeepSeek',
+							'summary' => 'Use DeepSeek capabilities in Block Editor',
+						],
+						'deepseek_token'  => [
+							'control'     => 'password',
+							'placeholder' => '',
+							'label'       => 'API Keys',
+							'summary'     => 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av',
+						],
+					],
+				],
 			]
 		);
 	}

--- a/tests/php/Core/AITest.php
+++ b/tests/php/Core/AITest.php
@@ -73,6 +73,15 @@ class AITest extends TestCase {
 		$ai->shouldReceive( 'get_provider' )
 			->andReturn( $open_ai );
 
+		\WP_Mock::userFunction( 'wp_strip_all_tags' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return strip_tags( $arg );
+				}
+			);
+
+		\WP_Mock::expectFilter( 'the_content', 'Generate an SEO friendly headline using: Hello World!' );
+
 		$open_ai->shouldReceive( 'run' )
 			->times( 1 )
 			->with(
@@ -103,6 +112,15 @@ class AITest extends TestCase {
 
 		$ai->shouldReceive( 'get_provider' )
 			->andReturn( $open_ai );
+
+		\WP_Mock::userFunction( 'wp_strip_all_tags' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return strip_tags( $arg );
+				}
+			);
+
+		\WP_Mock::expectFilter( 'the_content', 'Do nothing...' );
 
 		$open_ai->shouldReceive( 'run' )
 			->times( 1 )

--- a/tests/php/Providers/DeepSeekTest.php
+++ b/tests/php/Providers/DeepSeekTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace AiPlusBlockEditor\Tests\Providers;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use AiPlusBlockEditor\Providers\DeepSeek;
+
+/**
+ * @covers \AiPlusBlockEditor\Providers\DeepSeek::run
+ * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_api_url
+ * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_json_error
+ * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_notice
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_page
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_submit
+ * @covers \AiPlusBlockEditor\Admin\Options::init
+ */
+class DeepSeekTest extends TestCase {
+	public DeepSeek $deepseek;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->deepseek = new DeepSeek();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_get_default_args() {
+		\WP_Mock::expectFilter(
+			'apbe_deepseek_args',
+			[
+				'model'             => 'deepseek-chat',
+				'temperature'       => 0.7,
+				'top_p'             => 1,
+				'max_tokens'        => 500,
+				'presence_penalty'  => 0,
+				'frequency_penalty' => 0,
+			]
+		);
+
+		\WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		$reflection = new \ReflectionClass( $this->deepseek );
+		$method     = $reflection->getMethod( 'get_default_args' );
+
+		$method->setAccessible( true );
+		$args = $method->invoke( $this->deepseek );
+
+		$this->assertSame(
+			$args,
+			[
+				'model'             => 'deepseek-chat',
+				'temperature'       => 0.7,
+				'top_p'             => 1,
+				'max_tokens'        => 500,
+				'presence_penalty'  => 0,
+				'frequency_penalty' => 0,
+			]
+		);
+	}
+
+	public function test_get_api_url() {
+		$deepseek = Mockery::mock( DeepSeek::class )->makePartial();
+		$deepseek->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::expectFilter(
+			'apbe_deepseek_api_url',
+			'https://api.deepseek.com/chat/completions'
+		);
+
+		\WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		$url = $deepseek->get_api_url();
+
+		$this->assertSame( $url, 'https://api.deepseek.com/chat/completions' );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_api_keys_and_returns_wp_error() {
+		$deepseek = Mockery::mock( DeepSeek::class )->makePartial();
+		$deepseek->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'deepseek_token' => '',
+				]
+			);
+
+		$response = $deepseek->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_prompt_text_and_returns_wp_error() {
+		$deepseek = Mockery::mock( DeepSeek::class )->makePartial();
+		$deepseek->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'deepseek_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		$response = $deepseek->run(
+			[
+				'content' => '',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run() {
+		$deepseek = Mockery::mock( DeepSeek::class )->makePartial();
+		$deepseek->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$deepseek->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model'             => 'deepseek-chat',
+					'temperature'       => 0.7,
+					'top_p'             => 1,
+					'max_tokens'        => 500,
+					'presence_penalty'  => 0,
+					'frequency_penalty' => 0,
+				]
+			);
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'deepseek_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		\WP_Mock::userFunction( 'add_query_arg' )
+			->andReturnNull();
+
+		$deepseek->shouldReceive( 'get_api_url' )
+		->andReturn( '' );
+
+		\WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn( '{"body":{"choices":[{"message":{"content":"What a Wonderful World!"}}]}}' );
+
+		\WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
+
+		$response = $deepseek->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertSame( 'What a Wonderful World!', $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_json_error() {
+		$deepseek = Mockery::mock( DeepSeek::class )->makePartial();
+		$deepseek->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$response = $deepseek->get_json_error( 'API Error...' );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/php/Services/AdminTest.php
+++ b/tests/php/Services/AdminTest.php
@@ -243,6 +243,8 @@ class AdminTest extends TestCase {
 			->with(
 				'ai_plus_block_editor',
 				[
+					'deepseek_enable'      => '',
+					'deepseek_token'       => '',
 					'google_gemini_enable' => '',
 					'google_gemini_token'  => '',
 					'open_ai_enable'       => '',


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/23).

## Description / Background Context

At the moment, we currently have the OpenAI provider in place, which works correctly for users as expected. As a step further, we would like to implement the DeepSeek AI provider to enable users use DeepSeek as their AI option of choice. For reference pls see [DeepSeek API](https://api-docs.deepseek.com) link.

This PR focuses on implementing this correctly.

<img width="344" alt="Screenshot 2025-06-28 at 21 37 08" src="https://github.com/user-attachments/assets/2fdef9dc-5b87-4fef-8168-676fa53e5f13" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Select the **DeepSeek** AI provider.
4. Generate any of the sidebar features (headline, summary...).
5. Observe that it is working correctly.
6. All other features should work correctly as before without any regressions.