### PR TITLE
Feat: Implement Grok AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 1.7.0
+* Feat: Add Grok AI provider.
+* Feat: Implement custom filters `apbe_grok_api_url`, `apbe_grok_args`, `apbe_grok_system_prompt`.
+* Test: Update unit test cases.
+* Docs: Update README docs.
+* Tested up to WP 6.8.
+
 # 1.6.2
 * Update CI/CD build workflow.
 * Tested up to WP 6.8.2.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ public function custom_system_prompt( $prompt ) {
 }
 ```
 
+**Parameters**
+
+- prompt _`{string}`_ By default this will be a string containing the default system prompt.
+<br/>
+
 #### `apbe_open_ai_args`
 
 This custom hook (filter) provides the ability to modify the OpenAI args before it sent to the LLM.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,58 @@ public function custom_args( $args ) {
 - args _`{array}`_ By default this will be an array containing the Gemini default parameters.
 <br/>
 
+#### `apbe_grok_api_url`
+
+This custom hook (filter) provides the ability to modify the Grok endpoint used for generating AI content.
+
+```php
+add_filter( 'apbe_grok_api_url', [ $this, 'custom_api_url' ], 10, 1 );
+
+public function custom_api_url( $url ) {
+    return esc_url( 'https://api.x.ai/v2/chat/completions' );
+}
+```
+
+**Parameters**
+
+- url _`{string}`_ By default this will be a string containing the API endpoint for the Grok LLM.
+<br/>
+
+#### `apbe_grok_args`
+
+This custom hook (filter) provides the ability to modify the Grok args before it is sent to the LLM.
+
+```php
+add_filter( 'apbe_grok_args', [ $this, 'custom_args' ], 10, 1 );
+
+public function custom_args( $args ) {
+    return wp_parse_args(
+        [
+            'model'  => 'grok-5',
+            'stream' => false,
+        ],
+        $args
+    )
+}
+```
+
+**Parameters**
+
+- args _`{array}`_ By default this will be an array containing the Grok default parameters.
+<br/>
+
+#### `apbe_grok_system_prompt`
+
+This custom hook (filter) provides the ability to modify the Grok system prompt.
+
+```php
+add_filter( 'apbe_grok_system_prompt', [ $this, 'custom_system_prompt' ], 10, 1 );
+
+public function custom_system_prompt( $prompt ) {
+    return esc_html( 'You are Grok, a super-intelligent Journalist writing a cover story.' );
+}
+```
+
 #### `apbe_open_ai_args`
 
 This custom hook (filter) provides the ability to modify the OpenAI args before it sent to the LLM.

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -135,6 +135,7 @@ class Options {
 							'OpenAI'   => 'ChatGPT',
 							'Gemini'   => 'Gemini',
 							'DeepSeek' => 'DeepSeek',
+							'Grok'     => 'Grok',
 						],
 					],
 				],
@@ -180,6 +181,22 @@ class Options {
 						'summary' => esc_html__( 'Use DeepSeek capabilities in Block Editor', 'ai-plus-block-editor' ),
 					],
 					'deepseek_token'  => [
+						'control'     => esc_attr( 'password' ),
+						'placeholder' => esc_attr( '' ),
+						'label'       => esc_html__( 'API Keys', 'ai-plus-block-editor' ),
+						'summary'     => esc_html__( 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av', 'ai-plus-block-editor' ),
+					],
+				],
+			],
+			'grok_options'          => [
+				'heading'  => esc_html__( 'Grok', 'ai-plus-block-editor' ),
+				'controls' => [
+					'grok_enable' => [
+						'control' => esc_attr( 'checkbox' ),
+						'label'   => esc_html__( 'Enable Grok', 'ai-plus-block-editor' ),
+						'summary' => esc_html__( 'Use Grok capabilities in Block Editor', 'ai-plus-block-editor' ),
+					],
+					'grok_token'  => [
 						'control'     => esc_attr( 'password' ),
 						'placeholder' => esc_attr( '' ),
 						'label'       => esc_html__( 'API Keys', 'ai-plus-block-editor' ),

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Grok Class.
+ *
+ * This class is responsible for handling
+ * Grok calls.
+ *
+ * @package AiPlusBlockEditor
+ */
+
+namespace AiPlusBlockEditor\Providers;
+
+use AiPlusBlockEditor\Interfaces\Provider;
+use AiPlusBlockEditor\Admin\Options;
+
+class Grok implements Provider {
+	/**
+	 * Get Default Args.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return mixed[]
+	 */
+	protected function get_default_args(): array {
+		$args = [
+			'model'  => 'grok-4',
+			'stream' => false,
+		];
+
+		/**
+		 * Filter Grok default args.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param mixed[] $args Default args.
+		 * @return mixed[]
+		 */
+		$filtered_args = (array) apply_filters( 'apbe_grok_args', $args );
+
+		return wp_parse_args( $filtered_args, $args );
+	}
+
+	/**
+	 * Get API URL.
+	 *
+	 * This method returns the Grok API URL
+	 * endpoint. It can be filtered using the
+	 * 'apbe_grok_api_url' filter.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string
+	 */
+	protected function get_api_url(): string {
+		$url = esc_url( 'https://api.x.ai/v1/chat/completions' );
+
+		/**
+		 * Filter Grok API URL.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param string $url Grok API URL.
+		 * @return string
+		 */
+		return apply_filters( 'apbe_grok_api_url', $url );
+	}
+
+	/**
+	 * Get AI Response.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param mixed[] $payload JSON Payload.
+	 * @return string|\WP_Error
+	 */
+	public function run( $payload ) {
+		$api_key = get_option( Options::get_page_option(), [] )['grok_token'] ?? '';
+
+		if ( empty( $api_key ) ) {
+			return $this->get_json_error(
+				__( 'Missing Grok API key.', 'ai-plus-block-editor' )
+			);
+		}
+
+		// Default prompt if not passed.
+		$prompt_text = $payload['content'] ?? '';
+
+		// Validate prompt text.
+		if ( ! is_string( $prompt_text ) || empty( $prompt_text ) ) {
+			return $this->get_json_error(
+				__( 'Invalid prompt text.', 'ai-plus-block-editor' )
+			);
+		}
+
+		/**
+		 * Filter Grok System Prompt.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param string $prompt Grok System prompt.
+		 * @return string
+		 */
+		$system_prompt = apply_filters( 'apbe_grok_system_prompt', 'You are Grok, a highly intelligent, helpful AI assistant.' );
+
+		// Grok API expects a specific body structure.
+		$body = wp_parse_args(
+			$this->get_default_args(),
+			[
+				'messages' => [
+					[
+						'role'    => 'system',
+						'content' => $system_prompt,
+					],
+					[
+						'role'    => 'user',
+						'content' => $prompt_text,
+					],
+				],
+			]
+		);
+
+		$response = wp_remote_post(
+			$this->get_api_url(),
+			[
+				'headers' => [
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				],
+				'body'    => wp_json_encode( $body, JSON_UNESCAPED_UNICODE ),
+				'timeout' => 20,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $this->get_json_error( $response->get_error_message() );
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		// Notify user, if JSON yields null.
+		if ( empty( $data ) || ! isset( $data['choices'][0]['message']['content'] ) ) {
+			return $this->get_json_error(
+				$data['error']['message'] ?? __( 'Unexpected Grok API response.', 'ai-plus-block-editor' )
+			);
+		}
+
+		return $data['choices'][0]['message']['content'] ?? '';
+	}
+
+	/**
+	 * Get JSON Error.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $message Error Message.
+	 * @return \WP_Error
+	 */
+	protected function get_json_error( $message ) {
+		return new \WP_Error(
+			'ai-plus-block-editor-json-error',
+			$message,
+			[ 'status' => 500 ]
+		);
+	}
+}

--- a/src/components/Switcher.tsx
+++ b/src/components/Switcher.tsx
@@ -75,6 +75,7 @@ const Switcher = (): JSX.Element => {
 					{ label: 'ChatGPT', value: 'OpenAI' },
 					{ label: 'Gemini', value: 'Gemini' },
 					{ label: 'DeepSeek', value: 'DeepSeek' },
+					{ label: 'Grok', value: 'Grok' },
 				] }
 				onChange={ handleChange }
 				id="switcher"

--- a/tests/js/Switcher.test.tsx
+++ b/tests/js/Switcher.test.tsx
@@ -81,6 +81,7 @@ describe( 'Switcher', () => {
 		expect( getByText( 'ChatGPT' ) ).toBeVisible();
 		expect( getByText( 'Gemini' ) ).toBeVisible();
 		expect( getByText( 'DeepSeek' ) ).toBeVisible();
+		expect( getByText( 'Grok' ) ).toBeVisible();
 	} );
 
 	it( 'makes an API call request on selection change', async () => {

--- a/tests/js/__snapshots__/Switcher.test.tsx.snap
+++ b/tests/js/__snapshots__/Switcher.test.tsx.snap
@@ -26,6 +26,11 @@ exports[`Switcher renders Switcher component 1`] = `
     >
       DeepSeek
     </option>
+    <option
+      value="Grok"
+    >
+      Grok
+    </option>
   </select>
 </div>
 `;

--- a/tests/php/Admin/OptionsTest.php
+++ b/tests/php/Admin/OptionsTest.php
@@ -118,6 +118,7 @@ class OptionsTest extends TestCase {
 								'OpenAI'   => 'ChatGPT',
 								'Gemini'   => 'Gemini',
 								'DeepSeek' => 'DeepSeek',
+								'Grok'     => 'Grok',
 							],
 						],
 					],
@@ -163,6 +164,22 @@ class OptionsTest extends TestCase {
 							'summary' => 'Use DeepSeek capabilities in Block Editor',
 						],
 						'deepseek_token'  => [
+							'control'     => 'password',
+							'placeholder' => '',
+							'label'       => 'API Keys',
+							'summary'     => 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av',
+						],
+					],
+				],
+				'grok_options'          => [
+					'heading'  => 'Grok',
+					'controls' => [
+						'grok_enable' => [
+							'control' => 'checkbox',
+							'label'   => 'Enable Grok',
+							'summary' => 'Use Grok capabilities in Block Editor',
+						],
+						'grok_token'  => [
 							'control'     => 'password',
 							'placeholder' => '',
 							'label'       => 'API Keys',

--- a/tests/php/Providers/GrokTest.php
+++ b/tests/php/Providers/GrokTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace AiPlusBlockEditor\Tests\Providers;
+
+use WP_Mock;
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use AiPlusBlockEditor\Providers\Grok;
+
+/**
+ * @covers \AiPlusBlockEditor\Providers\Grok::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\Grok::get_api_url
+ * @covers \AiPlusBlockEditor\Providers\Grok::run
+ * @covers \AiPlusBlockEditor\Providers\Grok::get_json_error
+ * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_notice
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_page
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_submit
+ * @covers \AiPlusBlockEditor\Admin\Options::init
+ */
+class GrokTest extends TestCase {
+	public Grok $grok;
+
+	public function setUp(): void {
+		WP_Mock::setUp();
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		$this->grok = new Grok();
+	}
+
+	public function tearDown(): void {
+		WP_Mock::tearDown();
+	}
+
+	public function test_get_default_args() {
+		WP_Mock::expectFilter(
+			'apbe_grok_args',
+			[
+				'model'  => 'grok-4',
+				'stream' => false,
+			]
+		);
+
+		$reflection = new \ReflectionClass( $this->grok );
+		$method     = $reflection->getMethod( 'get_default_args' );
+
+		$method->setAccessible( true );
+		$args = $method->invoke( $this->grok );
+
+		$this->assertSame(
+			$args,
+			[
+				'model'  => 'grok-4',
+				'stream' => false,
+			]
+		);
+	}
+
+	public function test_get_api_url() {
+		$grok = Mockery::mock( Grok::class )->makePartial();
+		$grok->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::expectFilter(
+			'apbe_grok_api_url',
+			'https://api.x.ai/v1/chat/completions'
+		);
+
+		$url = $grok->get_api_url();
+
+		$this->assertSame( $url, 'https://api.x.ai/v1/chat/completions' );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_api_keys_and_returns_wp_error() {
+		$grok = Mockery::mock( Grok::class )->makePartial();
+		$grok->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'grok_token' => '',
+				]
+			);
+
+		$response = $grok->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_prompt_text_and_returns_wp_error() {
+		$grok = Mockery::mock( Grok::class )->makePartial();
+		$grok->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'deepseek_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		$response = $grok->run(
+			[
+				'content' => '',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_returns_wp_error_if_malformed_JSON_is_returned() {
+		$grok = Mockery::mock( Grok::class )->makePartial();
+		$grok->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$grok->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model'  => 'grok-4',
+					'stream' => false,
+				]
+			);
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'grok_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		WP_Mock::expectFilter(
+			'apbe_grok_system_prompt',
+			'You are Grok, a highly intelligent, helpful AI assistant.'
+		);
+
+		$grok->shouldReceive( 'get_api_url' )
+			->andReturn( '' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn( '{"body":{"choices":[{"message":{"content":"What a Wonderful World!"}}]}}' );
+
+		// Return malformed JSON response
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( '{"choices":[{"message":{"content":' );
+
+		$response = $grok->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run() {
+		$grok = Mockery::mock( Grok::class )->makePartial();
+		$grok->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$grok->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model'  => 'grok-4',
+					'stream' => false,
+				]
+			);
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'grok_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		WP_Mock::expectFilter(
+			'apbe_grok_system_prompt',
+			'You are Grok, a highly intelligent, helpful AI assistant.'
+		);
+
+		$grok->shouldReceive( 'get_api_url' )
+			->andReturn( '' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn( '{"body":{"choices":[{"message":{"content":"What a Wonderful World!"}}]}}' );
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
+
+		$response = $grok->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertSame( 'What a Wonderful World!', $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_json_error() {
+		$grok = Mockery::mock( Grok::class )->makePartial();
+		$grok->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$response = $grok->get_json_error( 'API Error...' );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/php/Services/AdminTest.php
+++ b/tests/php/Services/AdminTest.php
@@ -243,6 +243,8 @@ class AdminTest extends TestCase {
 			->with(
 				'ai_plus_block_editor',
 				[
+					'grok_enable'          => '',
+					'grok_token'           => '',
 					'deepseek_enable'      => '',
 					'deepseek_token'       => '',
 					'google_gemini_enable' => '',


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/55).

## Description / Background Context

At the moment, we currently have the OpenAI provider in place, which works correctly for users as expected. As a step further, we would like to implement the Grok AI provider to enable users use Grok as their AI option of choice. For reference pls see [Grok API](https://docs.x.ai/docs/tutorial) link.

This PR focuses on implementing this correctly.

<img width="284" height="217" alt="Screenshot 2025-09-13 at 10 55 11 AM" src="https://github.com/user-attachments/assets/12a6d297-b803-45ae-a29c-772d3ac2b77b" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `yarn build`.
3. Select the **Grok** AI provider.
4. Generate any of the sidebar features (headline, summary...).
5. Observe that it is working correctly.
6. All other features should work correctly as before without any regressions.