### PR TITLE
Refactor: Clean up AI Providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 # 1.8.0
 * Feat: Refactor AI providers.
-* Feat: Add custom filter - `apbe_deepseek_system_prompt`.
+* Feat: Add custom filters:
+  - `apbe_ai_provider_success_call`
+	- `apbe_ai_provider_fail_call`,
+	- `apbe_ai_provider_response`,
+	- `apbe_deepseek_system_prompt`.
+* Feat: Add error logging capabilities.
 * Feat: Implement AI provider abstraction.
+* Docs: Update README docs.
+* Test: Update unit tests.
+* Tested up to WP 6.8.2.
 
 # 1.7.1
 * Fix: Update issue with broken plugin deploy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 # 1.8.0
 * Feat: Refactor AI providers.
 * Feat: Add custom filters:
-  - `apbe_ai_provider_success_call`
-	- `apbe_ai_provider_fail_call`,
-	- `apbe_ai_provider_response`,
+  - `apbe_ai_provider_success_call`.
+	- `apbe_ai_provider_fail_call`.
+	- `apbe_ai_provider_response`.
 	- `apbe_deepseek_system_prompt`.
+  - `apbe_open_ai_system_prompt`.
 * Feat: Add error logging capabilities.
 * Feat: Implement AI provider abstraction.
 * Docs: Update README docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.8.0
+* Feat: Refactor AI providers.
+* Feat: Add custom filter - `apbe_deepseek_system_prompt`.
+* Feat: Implement AI provider abstraction.
+
 # 1.7.1
 * Fix: Update issue with broken plugin deploy.
 * Docs: Update README docs.

--- a/README.md
+++ b/README.md
@@ -346,6 +346,23 @@ public function custom_args( $args ) {
 - args _`{array}`_ By default this will be an array containing the OpenAI default parameters.
 <br/>
 
+#### `apbe_open_ai_system_prompt`
+
+This custom hook (filter) provides the ability to modify the OpenAI system prompt.
+
+```php
+add_filter( 'apbe_open_ai_system_prompt', [ $this, 'custom_system_prompt' ], 10, 1 );
+
+public function custom_system_prompt( $prompt ) {
+    return esc_html( 'You are ChatGPT, a super-intelligent Journalist writing a cover story.' );
+}
+```
+
+**Parameters**
+
+- prompt _`{string}`_ By default this will be a string containing the default system prompt.
+<br/>
+
 #### `apbe_tone_prompt`
 
 This custom hook provides a simple way to filter the tone used by the AI LLM endpoint.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ public function custom_args( $args ) {
 - args _`{array}`_ By default this will be an array containing the DeepSeek default parameters.
 <br/>
 
+#### `apbe_deepseek_system_prompt`
+
+This custom hook (filter) provides the ability to modify the DeepSeek system prompt.
+
+```php
+add_filter( 'apbe_deepseek_system_prompt', [ $this, 'custom_system_prompt' ], 10, 1 );
+
+public function custom_system_prompt( $prompt ) {
+    return esc_html( 'You are DeepSeek, a super-intelligent Journalist writing a cover story.' );
+}
+```
+
+**Parameters**
+
+- prompt _`{string}`_ By default this will be a string containing the default system prompt.
+<br/>
+
 #### `apbe_gemini_api_url`
 
 This custom hook (filter) provides the ability to modify the Gemini API endpoint used for generating AI content.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,92 @@ public function custom_ai_provider( $ai_provider ) {
 - ai_provider _`{Provider}`_ By default this will be an instance of the Provider interface that MUST contain a `run` method implementation.
 <br/>
 
+#### `apbe_ai_provider_response`
+
+This custom hook (filter) provides the ability to modify the AI Provider response from the LLM.
+
+```php
+add_filter( 'apbe_ai_provider_response', [ $this, 'custom_response' ], 10, 3 );
+
+public function custom_response( $message, $payload, $provider ) {
+    // Strip all HTML tags.
+    return wp_strip_all_tags( $message );
+}
+```
+
+**Parameters**
+
+- $message _`{string}`_ By default this will be a string containing the success message.
+- $payload _`{string}`_ By default this will be a string containing the JSON payload.
+- $provider _`{string}`_ By default this will be a string containing the provider name.
+<br/>
+
+#### `apbe_ai_provider_success_call`
+
+This custom hook (action) provides a way to fire events for successful AI provider calls.
+
+```php
+add_action( 'apbe_ai_provider_success_call', [ $this, 'log_successful_provider_call' ], 10, 3 );
+
+public function log_successful_provider_call( $message, $payload, $provider ) {
+    if ( 'OpenAI' === $provider ) {
+        wp_insert_post(
+            [
+                'post_type'    => 'chatgpt_successful_call',
+                'post_title'   => sprintf( 'Successful Call - %s', $provider ),
+                'post_content' => wp_json_encode(
+                    [
+                        'message'  => $message,
+                        'payload'  => $payload,
+                        'provider' => $provider,
+                    ]
+                )
+            ]
+        )
+    }
+}
+```
+
+**Parameters**
+
+- $message _`{string}`_ By default this will be a string containing the success message.
+- $payload _`{string}`_ By default this will be a string containing the JSON payload.
+- $provider _`{string}`_ By default this will be a string containing the provider name.
+<br/>
+
+#### `apbe_ai_provider_fail_call`
+
+This custom hook (action) provides a way to fire events for failed AI provider calls.
+
+```php
+add_action( 'apbe_ai_provider_fail_call', [ $this, 'log_failed_provider_call' ], 10, 3 );
+
+public function log_failed_provider_call( $message, $payload, $provider ) {
+    if ( 'Grok' === $provider ) {
+        wp_insert_post(
+            [
+                'post_type'    => 'grok_failed_call',
+                'post_title'   => sprintf( 'Failed Call - %s', $provider ),
+                'post_content' => wp_json_encode(
+                    [
+                        'message'  => $message,
+                        'payload'  => $payload,
+                        'provider' => $provider,
+                    ]
+                )
+            ]
+        )
+    }
+}
+```
+
+**Parameters**
+
+- $message _`{string}`_ By default this will be a string containing the fail message.
+- $payload _`{string}`_ By default this will be a string containing the JSON payload.
+- $provider _`{string}`_ By default this will be a string containing the provider name.
+<br/>
+
 #### `apbe_deepseek_api_url`
 
 This custom hook (filter) provides the ability to modify the DeepSeek endpoint used for generating AI content.
@@ -389,15 +475,15 @@ This custom hook (filter) provides the ability to extend the AiTone feature to o
 import { addFilter } from '@wordpress/hooks';
 
 addFilter(
-	'apbe.allowedBlocks',
-	'yourBlocks',
-	( allowedBlocks ) => {
-		if ( allowedBlocks.indexOf( 'your/block' ) === -1 ) {
-			allowedBlocks.push( 'your/block' );
-		}
+    'apbe.allowedBlocks',
+    'yourBlocks',
+    ( allowedBlocks ) => {
+        if ( allowedBlocks.indexOf( 'your/block' ) === -1 ) {
+            allowedBlocks.push( 'your/block' );
+        }
 
-		return allowedBlocks;
-	}
+        return allowedBlocks;
+    }
 );
 ```
 
@@ -414,15 +500,15 @@ This custom hook (filter) provides the ability to extend the menu options shown 
 import { addFilter } from '@wordpress/hooks';
 
 addFilter(
-	'apbe.blockMenuOptions',
-	'yourBlockMenuOptions',
-	( blockMenuOptions ) => {
-		const yourOptions = {
-			conversation: __( 'Use Conversation Tone', 'ai-plus-block-editor' )
-		}
+    'apbe.blockMenuOptions',
+    'yourBlockMenuOptions',
+    ( blockMenuOptions ) => {
+        const yourOptions = {
+            conversation: __( 'Use Conversation Tone', 'ai-plus-block-editor' )
+        }
 
-		return { ...blockMenuOptions, ...yourOptions }
-	}
+        return { ...blockMenuOptions, ...yourOptions }
+    }
 );
 ```
 

--- a/inc/Abstracts/Provider.php
+++ b/inc/Abstracts/Provider.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Provider abstraction.
+ *
+ * This abstract class defines the base class methods
+ * for provider concrete classes.
+ *
+ * @package AiPlusBlockEditor
+ */
+
+namespace AiPlusBlockEditor\Abstracts;
+
+use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
+
+/**
+ * Provider class.
+ */
+abstract class Provider implements ProviderInterface {
+	/**
+	 * Get Default Args.
+	 *
+	 * Define arguments that will most likely
+	 * be passed to the request body.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return mixed[]
+	 */
+	abstract protected function get_default_args();
+
+	/**
+	 * Run AI Prompt.
+	 *
+	 * Perform API call and get a response we
+	 * can proceed with.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param mixed[] $payload JSON Payload.
+	 * @return string|\WP_Error
+	 */
+	abstract public function run( $payload );
+
+	/**
+	 * Get JSON Error.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $message Error Message.
+	 * @return \WP_Error
+	 */
+	protected function get_json_error( $message ) {
+		return new \WP_Error(
+			'ai-plus-block-editor-json-error',
+			$message,
+			[ 'status' => 500 ]
+		);
+	}
+}

--- a/inc/Abstracts/Provider.php
+++ b/inc/Abstracts/Provider.php
@@ -50,6 +50,21 @@ abstract class Provider implements ProviderInterface {
 	 * @return \WP_Error
 	 */
 	protected function get_json_error( $message ) {
+		/**
+		 * Fire on failed Provider call.
+		 *
+		 * This provides a way to fire events on
+		 * failed AI Provider calls.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $message Error message.
+		 * @param string $class   Provider class.
+		 *
+		 * @return void
+		 */
+		do_action( 'apbe_failed_provider_call', $message, static::class );
+
 		return new \WP_Error(
 			'ai-plus-block-editor-json-error',
 			$message,

--- a/inc/Abstracts/Provider.php
+++ b/inc/Abstracts/Provider.php
@@ -17,6 +17,15 @@ use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
  */
 abstract class Provider implements ProviderInterface {
 	/**
+	 * Provider name.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var string
+	 */
+	protected static $name;
+
+	/**
 	 * Get Default Args.
 	 *
 	 * Define arguments that will most likely
@@ -46,10 +55,29 @@ abstract class Provider implements ProviderInterface {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @param string $message Error Message.
+	 * @param string  $message Error Message.
+	 * @param mixed[] $body    JSON payload.
+	 *
 	 * @return \WP_Error
 	 */
-	protected function get_json_error( $message ) {
+	protected function get_json_error( $message, $body = [] ) {
+		// Get Payload.
+		$payload = wp_json_encode( $body );
+
+		// Get Provider name.
+		$provider = static::$name;
+
+		// Add error logging capability.
+		error_log(
+			wp_json_encode(
+				[
+					'message'  => $message,
+					'payload'  => $payload,
+					'provider' => $provider,
+				]
+			)
+		);
+
 		/**
 		 * Fire on failed Provider call.
 		 *
@@ -58,12 +86,13 @@ abstract class Provider implements ProviderInterface {
 		 *
 		 * @since 1.8.0
 		 *
-		 * @param string $message Error message.
-		 * @param string $class   Provider class.
+		 * @param string $message  Error message.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
 		 *
 		 * @return void
 		 */
-		do_action( 'apbe_failed_provider_call', $message, static::class );
+		do_action( 'apbe_ai_provider_fail_call', $message, $payload, $provider );
 
 		return new \WP_Error(
 			'ai-plus-block-editor-json-error',

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -90,7 +90,7 @@ class AI implements Provider {
 		try {
 			return $this->get_provider()->run( $payload );
 		} catch ( \Exception $e ) {
-			/*return new \WP_Error(
+			return new \WP_Error(
 				'apbe-run-error',
 				sprintf( 'Server Error: %s', $e->getMessage() ),
 				[ 'status' => 500 ]

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -90,7 +90,7 @@ class AI implements Provider {
 		try {
 			return $this->get_provider()->run( $payload );
 		} catch ( \Exception $e ) {
-			return new \WP_Error(
+			/*return new \WP_Error(
 				'apbe-run-error',
 				sprintf( 'Server Error: %s', $e->getMessage() ),
 				[ 'status' => 500 ]

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -56,7 +56,7 @@ class DeepSeek implements Provider {
 	 * @return string
 	 */
 	protected function get_api_url(): string {
-		$url = esc_url( 'https://api.deepseek.com/chat/completions' );
+		$url = 'https://api.deepseek.com/chat/completions';
 
 		/**
 		 * Filter DeepSeek API URL.
@@ -66,7 +66,7 @@ class DeepSeek implements Provider {
 		 * @param string $url DeepSeek API URL.
 		 * @return string
 		 */
-		return apply_filters( 'apbe_deepseek_api_url', $url );
+		return esc_url( (string) apply_filters( 'apbe_deepseek_api_url', $url ) );
 	}
 
 	/**

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -16,6 +16,15 @@ use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
 
 class DeepSeek extends Provider implements ProviderInterface {
 	/**
+	 * Provider name.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var string
+	 */
+	protected static $name = 'DeepSeek';
+
+	/**
 	 * Get Default Args.
 	 *
 	 * @since 1.6.0
@@ -137,7 +146,7 @@ class DeepSeek extends Provider implements ProviderInterface {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $this->get_json_error( $response->get_error_message() );
+			return $this->get_json_error( $response->get_error_message(), $body );
 		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
@@ -145,10 +154,50 @@ class DeepSeek extends Provider implements ProviderInterface {
 		// Notify user, if JSON yields null.
 		if ( empty( $data ) || ! isset( $data['choices'][0]['message']['content'] ) ) {
 			return $this->get_json_error(
-				$data['error']['message'] ?? __( 'Unexpected DeepSeek API response.', 'ai-plus-block-editor' )
+				$data['error']['message'] ?? __( 'Unexpected DeepSeek API response.', 'ai-plus-block-editor' ),
+				$body
 			);
 		}
 
-		return $data['choices'][0]['message']['content'] ?? '';
+		// Get API response.
+		$response = $data['choices'][0]['message']['content'] ?? '';
+
+		// Get Payload.
+		$payload = wp_json_encode( $body );
+
+		// Get Provider name.
+		$provider = static::$name;
+
+		/**
+		 * Fire on successful Provider call.
+		 *
+		 * This provides a way to fire events on
+		 * successful AI Provider calls.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return void
+		 */
+		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
+
+		/**
+		 * Filter API response.
+		 *
+		 * This provides a way to filter the LLM
+		 * API response.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
 	}
 }

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -10,10 +10,11 @@
 
 namespace AiPlusBlockEditor\Providers;
 
-use AiPlusBlockEditor\Interfaces\Provider;
 use AiPlusBlockEditor\Admin\Options;
+use AiPlusBlockEditor\Abstracts\Provider;
+use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
 
-class DeepSeek implements Provider {
+class DeepSeek extends Provider implements ProviderInterface {
 	/**
 	 * Get Default Args.
 	 *
@@ -149,21 +150,5 @@ class DeepSeek implements Provider {
 		}
 
 		return $data['choices'][0]['message']['content'] ?? '';
-	}
-
-	/**
-	 * Get JSON Error.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $message Error Message.
-	 * @return \WP_Error
-	 */
-	protected function get_json_error( $message ) {
-		return new \WP_Error(
-			'ai-plus-block-editor-json-error',
-			$message,
-			[ 'status' => 500 ]
-		);
 	}
 }

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -96,13 +96,23 @@ class DeepSeek implements Provider {
 			);
 		}
 
+		/**
+		 * Filter DeepSeek System Prompt.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $prompt DeepSeek System prompt.
+		 * @return string
+		 */
+		$system_prompt = apply_filters( 'apbe_deepseek_system_prompt', 'You are a helpful assistant.' );
+
 		// DeepSeek API expects a specific body structure.
 		$body = wp_parse_args(
 			[
 				'messages' => [
 					[
 						'role'    => 'system',
-						'content' => 'You are a helpful assistant.',
+						'content' => $system_prompt,
 					],
 					[
 						'role'    => 'user',

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -141,6 +141,13 @@ class DeepSeek implements Provider {
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 
+		// Notify user, if JSON yields null.
+		if ( empty( $data ) || ! isset( $data['choices'][0]['message']['content'] ) ) {
+			return $this->get_json_error(
+				$data['error']['message'] ?? __( 'Unexpected DeepSeek API response.', 'ai-plus-block-editor' )
+			);
+		}
+
 		return $data['choices'][0]['message']['content'] ?? '';
 	}
 

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -10,10 +10,11 @@
 
 namespace AiPlusBlockEditor\Providers;
 
-use AiPlusBlockEditor\Interfaces\Provider;
 use AiPlusBlockEditor\Admin\Options;
+use AiPlusBlockEditor\Abstracts\Provider;
+use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
 
-class Gemini implements Provider {
+class Gemini extends Provider implements ProviderInterface {
 	/**
 	 * Get Default Args.
 	 *
@@ -140,21 +141,5 @@ class Gemini implements Provider {
 		}
 
 		return $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
-	}
-
-	/**
-	 * Get JSON Error.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $message Error Message.
-	 * @return \WP_Error
-	 */
-	protected function get_json_error( $message ) {
-		return new \WP_Error(
-			'ai-plus-block-editor-json-error',
-			$message,
-			[ 'status' => 500 ]
-		);
 	}
 }

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -134,8 +134,11 @@ class Gemini implements Provider {
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		if ( isset( $data['error'] ) ) {
-			return $this->get_json_error( $data['error']['message'] ?? 'Unknown Gemini API error.' );
+		// Notify user, if JSON yields null.
+		if ( empty( $data ) || ! isset( $data['candidates'][0]['content']['parts'][0]['text'] ) ) {
+			return $this->get_json_error(
+				$data['error']['message'] ?? __( 'Unexpected Gemini API response.', 'ai-plus-block-editor' )
+			);
 		}
 
 		return $data['candidates'][0]['content']['parts'][0]['text'] ?? '';

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -56,11 +56,9 @@ class Gemini implements Provider {
 	 * @return string
 	 */
 	protected function get_api_url(): string {
-		$url = esc_url(
-			sprintf(
-				'https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent',
-				$this->get_default_args()['model'] ?? ''
-			)
+		$url = sprintf(
+			'https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent',
+			$this->get_default_args()['model'] ?? ''
 		);
 
 		/**
@@ -71,7 +69,7 @@ class Gemini implements Provider {
 		 * @param string $url Gemini API URL.
 		 * @return string
 		 */
-		return apply_filters( 'apbe_gemini_api_url', $url );
+		return esc_url( (string) apply_filters( 'apbe_gemini_api_url', $url ) );
 	}
 
 	/**

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -52,7 +52,7 @@ class Grok implements Provider {
 	 * @return string
 	 */
 	protected function get_api_url(): string {
-		$url = esc_url( 'https://api.x.ai/v1/chat/completions' );
+		$url = 'https://api.x.ai/v1/chat/completions';
 
 		/**
 		 * Filter Grok API URL.
@@ -62,7 +62,7 @@ class Grok implements Provider {
 		 * @param string $url Grok API URL.
 		 * @return string
 		 */
-		return apply_filters( 'apbe_grok_api_url', $url );
+		return esc_url( (string) apply_filters( 'apbe_grok_api_url', $url ) );
 	}
 
 	/**

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -104,7 +104,6 @@ class Grok implements Provider {
 
 		// Grok API expects a specific body structure.
 		$body = wp_parse_args(
-			$this->get_default_args(),
 			[
 				'messages' => [
 					[
@@ -116,7 +115,8 @@ class Grok implements Provider {
 						'content' => $prompt_text,
 					],
 				],
-			]
+			],
+			$this->get_default_args(),
 		);
 
 		$response = wp_remote_post(

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -16,6 +16,15 @@ use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
 
 class Grok extends Provider implements ProviderInterface {
 	/**
+	 * Provider name.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var string
+	 */
+	protected static $name = 'Grok';
+
+	/**
 	 * Get Default Args.
 	 *
 	 * @since 1.7.0
@@ -133,7 +142,7 @@ class Grok extends Provider implements ProviderInterface {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $this->get_json_error( $response->get_error_message() );
+			return $this->get_json_error( $response->get_error_message(), $body );
 		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
@@ -141,10 +150,50 @@ class Grok extends Provider implements ProviderInterface {
 		// Notify user, if JSON yields null.
 		if ( empty( $data ) || ! isset( $data['choices'][0]['message']['content'] ) ) {
 			return $this->get_json_error(
-				$data['error']['message'] ?? __( 'Unexpected Grok API response.', 'ai-plus-block-editor' )
+				$data['error']['message'] ?? __( 'Unexpected Grok API response.', 'ai-plus-block-editor' ),
+				$body
 			);
 		}
 
-		return $data['choices'][0]['message']['content'] ?? '';
+		// Get API response.
+		$response = $data['choices'][0]['message']['content'] ?? '';
+
+		// Get Payload.
+		$payload = wp_json_encode( $body );
+
+		// Get Provider name.
+		$provider = static::$name;
+
+		/**
+		 * Fire on successful Provider call.
+		 *
+		 * This provides a way to fire events on
+		 * successful AI Provider calls.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return void
+		 */
+		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
+
+		/**
+		 * Filter API response.
+		 *
+		 * This provides a way to filter the LLM
+		 * API response.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
 	}
 }

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -10,10 +10,11 @@
 
 namespace AiPlusBlockEditor\Providers;
 
-use AiPlusBlockEditor\Interfaces\Provider;
 use AiPlusBlockEditor\Admin\Options;
+use AiPlusBlockEditor\Abstracts\Provider;
+use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
 
-class Grok implements Provider {
+class Grok extends Provider implements ProviderInterface {
 	/**
 	 * Get Default Args.
 	 *
@@ -145,21 +146,5 @@ class Grok implements Provider {
 		}
 
 		return $data['choices'][0]['message']['content'] ?? '';
-	}
-
-	/**
-	 * Get JSON Error.
-	 *
-	 * @since 1.7.0
-	 *
-	 * @param string $message Error Message.
-	 * @return \WP_Error
-	 */
-	protected function get_json_error( $message ) {
-		return new \WP_Error(
-			'ai-plus-block-editor-json-error',
-			$message,
-			[ 'status' => 500 ]
-		);
 	}
 }

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -11,10 +11,12 @@
 namespace AiPlusBlockEditor\Providers;
 
 use Orhanerday\OpenAi\OpenAi as ChatGPT;
-use AiPlusBlockEditor\Admin\Options;
-use AiPlusBlockEditor\Interfaces\Provider;
 
-class OpenAI implements Provider {
+use AiPlusBlockEditor\Admin\Options;
+use AiPlusBlockEditor\Abstracts\Provider;
+use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
+
+class OpenAI extends Provider implements ProviderInterface {
 	/**
 	 * Get Default Args.
 	 *
@@ -123,21 +125,5 @@ class OpenAI implements Provider {
 		}
 
 		return $response['choices'][0]['message']['content'] ?? '';
-	}
-
-	/**
-	 * Get JSON Error.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $message Error Message.
-	 * @return \WP_Error
-	 */
-	protected function get_json_error( $message ) {
-		return new \WP_Error(
-			'ai-plus-block-editor-json-error',
-			$message,
-			[ 'status' => 500 ]
-		);
 	}
 }

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -118,7 +118,7 @@ class OpenAI extends Provider implements ProviderInterface {
 					[
 						'role'    => 'user',
 						'content' => $prompt_text,
-					]
+					],
 				],
 			],
 			$this->get_default_args()

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -97,10 +97,24 @@ class OpenAI extends Provider implements ProviderInterface {
 			);
 		}
 
+		/**
+		 * Filter OpenAI System Prompt.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $prompt OpenAI System prompt.
+		 * @return string
+		 */
+		$system_prompt = apply_filters( 'apbe_open_ai_system_prompt', 'You are ChatGPT, a highly intelligent, helpful AI assistant.' );
+
 		// ChatGPT expects a specific body structure.
 		$body = wp_parse_args(
 			[
 				'messages' => [
+					[
+						'role'    => 'system',
+						'content' => $system_prompt,
+					],
 					[
 						'role'    => 'user',
 						'content' => $prompt_text,

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -101,8 +101,10 @@ class OpenAI extends Provider implements ProviderInterface {
 		$body = wp_parse_args(
 			[
 				'messages' => [
-					'role'    => 'user',
-					'content' => $prompt_text,
+					[
+						'role'    => 'user',
+						'content' => $prompt_text,
+					]
 				],
 			],
 			$this->get_default_args()

--- a/readme.txt
+++ b/readme.txt
@@ -71,10 +71,11 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 = 1.8.0 =
 * Feat: Refactor AI providers.
 * Feat: Add custom filters:
-  - `apbe_ai_provider_success_call`
-  - `apbe_ai_provider_fail_call`,
-  - `apbe_ai_provider_response`,
+  - `apbe_ai_provider_success_call`.
+  - `apbe_ai_provider_fail_call`.
+  - `apbe_ai_provider_response`.
   - `apbe_deepseek_system_prompt`.
+  - `apbe_open_ai_system_prompt`.
 * Feat: Add error logging capabilities.
 * Feat: Implement AI provider abstraction.
 * Docs: Update README docs.

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,11 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.8.0 =
+* Feat: Refactor AI providers.
+* Feat: Add custom filter - `apbe_deepseek_system_prompt`.
+* Feat: Implement AI provider abstraction.
+
 = 1.7.1 =
 * Fix: Update issue with broken plugin deploy.
 * Docs: Update README docs.

--- a/readme.txt
+++ b/readme.txt
@@ -70,8 +70,16 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = 1.8.0 =
 * Feat: Refactor AI providers.
-* Feat: Add custom filter - `apbe_deepseek_system_prompt`.
+* Feat: Add custom filters:
+  - `apbe_ai_provider_success_call`
+  - `apbe_ai_provider_fail_call`,
+  - `apbe_ai_provider_response`,
+  - `apbe_deepseek_system_prompt`.
+* Feat: Add error logging capabilities.
 * Feat: Implement AI provider abstraction.
+* Docs: Update README docs.
+* Test: Update unit tests.
+* Tested up to WP 6.8.2.
 
 = 1.7.1 =
 * Fix: Update issue with broken plugin deploy.

--- a/tests/php/Abstracts/ProviderTest.php
+++ b/tests/php/Abstracts/ProviderTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace AiPlusBlockEditor\Tests\Abstracts;
+
+use WP_Mock;
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use AiPlusBlockEditor\Abstracts\Provider;
+
+/**
+ * @covers \AiPlusBlockEditor\Abstracts\Provider::get_default_args
+ * @covers \AiPlusBlockEditor\Abstracts\Provider::get_json_error
+ * @covers \AiPlusBlockEditor\Abstracts\Provider::run
+ */
+class ProviderTest extends TestCase {
+	public Provider $provider;
+
+	public function setUp(): void {
+		WP_Mock::setUp();
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		$this->provider = Mockery::mock( ConcreteProvider::class )->makePartial();
+		$this->provider->shouldAllowMockingProtectedMethods();
+	}
+
+	public function tearDown(): void {
+		WP_Mock::tearDown();
+	}
+
+	public function test_get_default_args() {
+		$response = $this->provider->get_default_args();
+
+		$this->assertSame(
+			[
+				'model' => 'ai_model',
+			],
+			$response
+		);
+	}
+
+	public function test_get_json_error() {
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'API Error...',
+			'[]',
+			'AI Provider',
+		);
+
+		$response = $this->provider->get_json_error( 'API Error...' );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run() {
+		$this->provider->run(
+			[
+				'content' => 'Generate me a beautiful headline for my Graduation!'
+			]
+		);
+
+		$this->expectOutputString(
+			'{"content":"Generate me a beautiful headline for my Graduation!"}'
+		);
+		$this->assertConditionsMet();
+	}
+}
+
+class ConcreteProvider extends Provider {
+	protected static $name = 'AI Provider';
+
+	protected function get_default_args() {
+		return [
+			'model' => 'ai_model',
+		];
+	}
+
+	public function run( $payload ) {
+		echo wp_json_encode( $payload );
+	}
+}

--- a/tests/php/Abstracts/ProviderTest.php
+++ b/tests/php/Abstracts/ProviderTest.php
@@ -106,7 +106,7 @@ class ProviderTest extends TestCase {
 	public function test_run() {
 		$this->provider->run(
 			[
-				'content' => 'Generate me a beautiful headline for my Graduation!'
+				'content' => 'Generate me a beautiful headline for my Graduation!',
 			]
 		);
 

--- a/tests/php/Abstracts/RouteTest.php
+++ b/tests/php/Abstracts/RouteTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Abstracts;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Core\AI;
@@ -19,13 +20,13 @@ class RouteTest extends TestCase {
 	public Route $route;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->route = new ConcreteRoute();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_request_returns_response() {
@@ -71,7 +72,7 @@ class RouteTest extends TestCase {
 	}
 
 	public function test_register_route() {
-		\WP_Mock::userFunction( 'register_rest_route' )
+		WP_Mock::userFunction( 'register_rest_route' )
 			->with(
 				'ai-plus-block-editor/v1',
 				'/sidebar',
@@ -123,10 +124,10 @@ class RouteTest extends TestCase {
 	}
 
 	public function test_is_user_permissible_returns_error_if_not_administrator() {
-		\WP_Mock::userFunction( 'rest_authorization_required_code' )
+		WP_Mock::userFunction( 'rest_authorization_required_code' )
 			->andReturn( 403 );
 
-		\WP_Mock::userFunction( 'current_user_can' )
+		WP_Mock::userFunction( 'current_user_can' )
 			->with( 'administrator' )
 			->andReturn( false );
 
@@ -143,14 +144,14 @@ class RouteTest extends TestCase {
 	}
 
 	public function test_is_user_permissible_returns_error_if_nonce_fails() {
-		\WP_Mock::userFunction( 'rest_authorization_required_code' )
+		WP_Mock::userFunction( 'rest_authorization_required_code' )
 			->andReturn( 403 );
 
-		\WP_Mock::userFunction( 'current_user_can' )
+		WP_Mock::userFunction( 'current_user_can' )
 			->with( 'administrator' )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->with( 'a8ceg59jeqwvk', 'wp_rest' )
 			->andReturn( false );
 
@@ -171,10 +172,10 @@ class RouteTest extends TestCase {
 	}
 
 	public function test_is_user_permissible_passes_correctly() {
-		\WP_Mock::userFunction( 'rest_authorization_required_code' )
+		WP_Mock::userFunction( 'rest_authorization_required_code' )
 			->andReturn( 403 );
 
-		\WP_Mock::userFunction( 'current_user_can' )
+		WP_Mock::userFunction( 'current_user_can' )
 			->with( 'administrator' )
 			->andReturn( true );
 
@@ -185,7 +186,7 @@ class RouteTest extends TestCase {
 			->with( 'X-WP-Nonce' )
 			->andReturn( 'a8ceg59jeqwvk' );
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->with( 'a8ceg59jeqwvk', 'wp_rest' )
 			->andReturn( true );
 

--- a/tests/php/Abstracts/ServiceTest.php
+++ b/tests/php/Abstracts/ServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Abstracts;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Abstracts\Service;
@@ -11,11 +12,11 @@ use AiPlusBlockEditor\Abstracts\Service;
  */
 class ServiceTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_instance_returns_same_instance() {

--- a/tests/php/Admin/FormTest.php
+++ b/tests/php/Admin/FormTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Admin;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Admin\Form;
@@ -27,7 +28,7 @@ class FormTest extends TestCase {
 	public Form $form;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->form = Mockery::mock( Form::class )->makePartial();
 		$this->form->shouldAllowMockingProtectedMethods();
@@ -68,7 +69,7 @@ class FormTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_options() {
@@ -113,21 +114,21 @@ class FormTest extends TestCase {
 	public function test_get_form_action() {
 		$_SERVER['REQUEST_URI'] = 'https://example.com/\/';
 
-		\WP_Mock::userFunction( 'esc_url' )
+		WP_Mock::userFunction( 'esc_url' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( filter_var( $arg, FILTER_SANITIZE_URL ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return stripslashes( $arg );
@@ -140,7 +141,7 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_form_main() {
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_form_fields',
 			[
 				'form_group_1',
@@ -222,7 +223,7 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_setting() {
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'plugin_option', [] )
 			->andReturn(
 				[
@@ -411,7 +412,7 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_form_submit() {
-		\WP_Mock::userFunction( 'wp_nonce_field' )
+		WP_Mock::userFunction( 'wp_nonce_field' )
 			->with( 'nonce_action', 'nonce_name', true, false )
 			->andReturn( '<input type="hidden" id="nonce_name" name="nonce_name" value="a8gkfhvzhi" />' );
 
@@ -437,21 +438,21 @@ class FormTest extends TestCase {
 		$_POST['button_name'] = null;
 		$_POST['nonce_name']  = 'nonce_action\/';
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( stripslashes( $arg ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return $arg1 === $arg2;
@@ -470,21 +471,21 @@ class FormTest extends TestCase {
 		$_POST['button_name'] = true;
 		$_POST['nonce_name']  = 'incorrect_action_name\/';
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( stripslashes( $arg ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return $arg1 === $arg2;
@@ -503,21 +504,21 @@ class FormTest extends TestCase {
 		$_POST['button_name'] = true;
 		$_POST['nonce_name']  = 'nonce_action\/';
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( stripslashes( $arg ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return $arg1 === $arg2;

--- a/tests/php/Admin/OptionsTest.php
+++ b/tests/php/Admin/OptionsTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Admin;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Admin\Options;
@@ -14,15 +15,15 @@ use AiPlusBlockEditor\Admin\Options;
  */
 class OptionsTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_form_page() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 2,
@@ -46,7 +47,7 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_submit() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 2,
@@ -75,7 +76,7 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_fields() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -84,7 +85,7 @@ class OptionsTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -93,7 +94,7 @@ class OptionsTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -192,7 +193,7 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_notice() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 1,

--- a/tests/php/Core/AITest.php
+++ b/tests/php/Core/AITest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Core;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Core\AI;
@@ -16,15 +17,15 @@ class AITest extends TestCase {
 	public AI $ai;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_provider() {
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -55,7 +56,7 @@ class AITest extends TestCase {
 		$open_ai = Mockery::mock( OpenAI::class )->makePartial();
 		$open_ai->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::expectFilter( 'apbe_ai_provider', $open_ai );
+		WP_Mock::expectFilter( 'apbe_ai_provider', $open_ai );
 
 		$instance = $ai->get_instance( $open_ai );
 
@@ -73,14 +74,14 @@ class AITest extends TestCase {
 		$ai->shouldReceive( 'get_provider' )
 			->andReturn( $open_ai );
 
-		\WP_Mock::userFunction( 'wp_strip_all_tags' )
+		WP_Mock::userFunction( 'wp_strip_all_tags' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return strip_tags( $arg );
 				}
 			);
 
-		\WP_Mock::expectFilter( 'the_content', 'Generate an SEO friendly headline using: Hello World!' );
+		WP_Mock::expectFilter( 'the_content', 'Generate an SEO friendly headline using: Hello World!' );
 
 		$open_ai->shouldReceive( 'run' )
 			->times( 1 )
@@ -113,14 +114,14 @@ class AITest extends TestCase {
 		$ai->shouldReceive( 'get_provider' )
 			->andReturn( $open_ai );
 
-		\WP_Mock::userFunction( 'wp_strip_all_tags' )
+		WP_Mock::userFunction( 'wp_strip_all_tags' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return strip_tags( $arg );
 				}
 			);
 
-		\WP_Mock::expectFilter( 'the_content', 'Do nothing...' );
+		WP_Mock::expectFilter( 'the_content', 'Do nothing...' );
 
 		$open_ai->shouldReceive( 'run' )
 			->times( 1 )

--- a/tests/php/Core/ContainerTest.php
+++ b/tests/php/Core/ContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Core;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 
@@ -27,11 +28,11 @@ class ContainerTest extends TestCase {
 	public Container $container;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_container_contains_required_services() {
@@ -55,7 +56,7 @@ class ContainerTest extends TestCase {
 			$service::get_instance();
 		}
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_init',
 			[
 				Service::$services[ Admin::class ],
@@ -63,7 +64,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_menu',
 			[
 				Service::$services[ Admin::class ],
@@ -71,7 +72,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_enqueue_scripts',
 			[
 				Service::$services[ Admin::class ],
@@ -79,7 +80,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'init',
 			[
 				Service::$services[ Boot::class ],
@@ -87,7 +88,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'enqueue_block_editor_assets',
 			[
 				Service::$services[ Boot::class ],
@@ -95,7 +96,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'init',
 			[
 				Service::$services[ PostMeta::class ],
@@ -103,7 +104,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'rest_api_init',
 			[
 				Service::$services[ Routes::class ],

--- a/tests/php/Interfaces/KernelTest.php
+++ b/tests/php/Interfaces/KernelTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Interfaces;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Interfaces\Kernel;
@@ -13,13 +14,13 @@ class KernelTest extends TestCase {
 	public Kernel $kernel;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->kernel = $this->getMockForAbstractClass( Kernel::class );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {

--- a/tests/php/Interfaces/ProviderTest.php
+++ b/tests/php/Interfaces/ProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Interfaces;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Interfaces\Provider;
@@ -13,13 +14,13 @@ class ProviderTest extends TestCase {
 	public Provider $provider;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->provider = $this->getMockForAbstractClass( Provider::class );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_run() {

--- a/tests/php/Interfaces/RouterTest.php
+++ b/tests/php/Interfaces/RouterTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Interfaces;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Interfaces\Router;
@@ -15,13 +16,13 @@ class RouterTest extends TestCase {
 	public Router $router;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->router = $this->getMockForAbstractClass( Router::class );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_response() {

--- a/tests/php/PluginTest.php
+++ b/tests/php/PluginTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Plugin;
@@ -12,11 +13,11 @@ use AiPlusBlockEditor\Abstracts\Kernel;
  */
 class PluginTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_plugin_returns_same_instance() {

--- a/tests/php/Providers/DeepSeekTest.php
+++ b/tests/php/Providers/DeepSeekTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Providers;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Providers\DeepSeek;
@@ -22,17 +23,66 @@ class DeepSeekTest extends TestCase {
 	public DeepSeek $deepseek;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
 
 		$this->deepseek = new DeepSeek();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_default_args() {
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_deepseek_args',
 			[
 				'model'             => 'deepseek-chat',
@@ -43,13 +93,6 @@ class DeepSeekTest extends TestCase {
 				'frequency_penalty' => 0,
 			]
 		);
-
-		\WP_Mock::userFunction( 'wp_parse_args' )
-			->andReturnUsing(
-				function ( $arg1, $arg2 ) {
-					return array_merge( $arg2, $arg1 );
-				}
-			);
 
 		$reflection = new \ReflectionClass( $this->deepseek );
 		$method     = $reflection->getMethod( 'get_default_args' );
@@ -74,7 +117,7 @@ class DeepSeekTest extends TestCase {
 		$deepseek = Mockery::mock( DeepSeek::class )->makePartial();
 		$deepseek->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_deepseek_api_url',
 			'https://api.deepseek.com/chat/completions'
 		);
@@ -99,28 +142,7 @@ class DeepSeekTest extends TestCase {
 		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_attr' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( '__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[

--- a/tests/php/Providers/DeepSeekTest.php
+++ b/tests/php/Providers/DeepSeekTest.php
@@ -260,7 +260,7 @@ class DeepSeekTest extends TestCase {
 				}
 			);
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -273,16 +273,16 @@ class DeepSeekTest extends TestCase {
 			'You are a helpful assistant.'
 		);
 
-		\WP_Mock::userFunction( 'add_query_arg' )
+		WP_Mock::userFunction( 'add_query_arg' )
 			->andReturnNull();
 
 		$deepseek->shouldReceive( 'get_api_url' )
 		->andReturn( '' );
 
-		\WP_Mock::userFunction( 'wp_remote_post' )
+		WP_Mock::userFunction( 'wp_remote_post' )
 			->andReturn( '{"body":{"choices":[{"message":{"content":"What a Wonderful World!"}}]}}' );
 
-		\WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
 			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
 
 		$response = $deepseek->run(

--- a/tests/php/Providers/DeepSeekTest.php
+++ b/tests/php/Providers/DeepSeekTest.php
@@ -246,6 +246,11 @@ class DeepSeekTest extends TestCase {
 				]
 			);
 
+		WP_Mock::expectFilter(
+			'apbe_deepseek_system_prompt',
+			'You are a helpful assistant.'
+		);
+
 		\WP_Mock::userFunction( 'add_query_arg' )
 			->andReturnNull();
 

--- a/tests/php/Providers/GeminiTest.php
+++ b/tests/php/Providers/GeminiTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Providers;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Providers\Gemini;
@@ -22,17 +23,73 @@ class GeminiTest extends TestCase {
 	public Gemini $gemini;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		WP_Mock::userFunction( 'add_query_arg' )
+			->andReturnUsing(
+				function ( $arg1, $arg2, $arg3 ) {
+					return sprintf( '%s?%s=%s', $arg3, $arg1, $arg2 );
+				}
+			);
 
 		$this->gemini = new Gemini();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_default_args() {
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_gemini_args',
 			[
 				'model'           => 'gemini-2.0-flash',
@@ -81,7 +138,7 @@ class GeminiTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_gemini_api_url',
 			'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
 		);

--- a/tests/php/Providers/GeminiTest.php
+++ b/tests/php/Providers/GeminiTest.php
@@ -302,7 +302,7 @@ class GeminiTest extends TestCase {
 				}
 			);
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -310,16 +310,16 @@ class GeminiTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'add_query_arg' )
+		WP_Mock::userFunction( 'add_query_arg' )
 			->andReturnNull();
 
 		$gemini->shouldReceive( 'get_api_url' )
 		->andReturn( '' );
 
-		\WP_Mock::userFunction( 'wp_remote_post' )
+		WP_Mock::userFunction( 'wp_remote_post' )
 			->andReturn( '{"body":{"candidates":[{"content":{"parts":[{"text":"What a Wonderful World!"}]}}]}}' );
 
-		\WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
 			->andReturn( '{"candidates":[{"content":{"parts":[{"text":"What a Wonderful World!"}]}}]}' );
 
 		$response = $gemini->run(

--- a/tests/php/Providers/GrokTest.php
+++ b/tests/php/Providers/GrokTest.php
@@ -163,7 +163,7 @@ class GrokTest extends TestCase {
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
-					'deepseek_token' => 'age38gegewjdhagepkhif',
+					'grok_token' => 'age38gegewjdhagepkhif',
 				]
 			);
 

--- a/tests/php/Providers/GrokTest.php
+++ b/tests/php/Providers/GrokTest.php
@@ -135,6 +135,13 @@ class GrokTest extends TestCase {
 				]
 			);
 
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Missing Grok API key.',
+			'[]',
+			'Grok',
+		);
+
 		$response = $grok->run(
 			[
 				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
@@ -159,6 +166,13 @@ class GrokTest extends TestCase {
 					'deepseek_token' => 'age38gegewjdhagepkhif',
 				]
 			);
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Invalid prompt text.',
+			'[]',
+			'Grok',
+		);
 
 		$response = $grok->run(
 			[
@@ -208,6 +222,13 @@ class GrokTest extends TestCase {
 		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
 			->andReturn( '{"choices":[{"message":{"content":' );
 
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Unexpected Grok API response.',
+			'{"model":"grok-4","stream":false,"messages":[{"role":"system","content":"You are Grok, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
+			'Grok',
+		);
+
 		$response = $grok->run(
 			[
 				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
@@ -255,6 +276,20 @@ class GrokTest extends TestCase {
 		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
 			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
 
+		WP_Mock::expectAction(
+			'apbe_ai_provider_success_call',
+			'What a Wonderful World!',
+			'{"model":"grok-4","stream":false,"messages":[{"role":"system","content":"You are Grok, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
+			'Grok',
+		);
+
+		WP_Mock::expectFilter(
+			'apbe_ai_provider_response',
+			'What a Wonderful World!',
+			'{"model":"grok-4","stream":false,"messages":[{"role":"system","content":"You are Grok, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
+			'Grok',
+		);
+
 		$response = $grok->run(
 			[
 				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
@@ -271,6 +306,13 @@ class GrokTest extends TestCase {
 
 		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'API Error...',
+			'[]',
+			'Grok',
+		);
 
 		$response = $grok->get_json_error( 'API Error...' );
 

--- a/tests/php/Providers/GrokTest.php
+++ b/tests/php/Providers/GrokTest.php
@@ -27,15 +27,15 @@ class GrokTest extends TestCase {
 
 		WP_Mock::userFunction( '__' )
 			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
+				function ( $arg1, $arg2 ) {
+					return $arg1;
 				}
 			);
 
 		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
+				function ( $arg1, $arg2 ) {
+					return $arg1;
 				}
 			);
 

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -229,20 +229,25 @@ class OpenAITest extends TestCase {
 				]
 			);
 
+		WP_Mock::expectFilter(
+			'apbe_open_ai_system_prompt',
+			'You are ChatGPT, a highly intelligent, helpful AI assistant.'
+		);
+
 		$chat_gpt->shouldReceive( 'chat' )
 			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
 
 		WP_Mock::expectAction(
 			'apbe_ai_provider_success_call',
 			'What a Wonderful World!',
-			'{"model":"gpt-3.5-turbo","temperature":1,"max_tokens":4000,"frequency_penalty":0,"presence_penalty":0,"messages":{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}}',
+			'{"model":"gpt-3.5-turbo","temperature":1,"max_tokens":4000,"frequency_penalty":0,"presence_penalty":0,"messages":[{"role":"system","content":"You are ChatGPT, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
 			'OpenAI',
 		);
 
 		WP_Mock::expectFilter(
 			'apbe_ai_provider_response',
 			'What a Wonderful World!',
-			'{"model":"gpt-3.5-turbo","temperature":1,"max_tokens":4000,"frequency_penalty":0,"presence_penalty":0,"messages":{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}}',
+			'{"model":"gpt-3.5-turbo","temperature":1,"max_tokens":4000,"frequency_penalty":0,"presence_penalty":0,"messages":[{"role":"system","content":"You are ChatGPT, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
 			'OpenAI',
 		);
 

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -94,13 +94,6 @@ class OpenAITest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'wp_parse_args' )
-			->andReturnUsing(
-				function ( $arg1, $arg2 ) {
-					return array_merge( $arg2, $arg1 );
-				}
-			);
-
 		$reflection = new \ReflectionClass( $this->open_ai );
 		$method     = $reflection->getMethod( 'get_default_args' );
 
@@ -123,21 +116,7 @@ class OpenAITest extends TestCase {
 		$open_ai = Mockery::mock( OpenAI::class )->makePartial();
 		$open_ai->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_attr' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -155,28 +134,7 @@ class OpenAITest extends TestCase {
 		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_attr' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( '__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -208,28 +166,7 @@ class OpenAITest extends TestCase {
 		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_attr' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( '__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -284,28 +221,7 @@ class OpenAITest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_attr' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'wp_parse_args' )
-			->andReturnUsing(
-				function ( $arg1, $arg2 ) {
-					return array_merge( $arg2, $arg1 );
-				}
-			);
-
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -184,6 +184,13 @@ class OpenAITest extends TestCase {
 				]
 			);
 
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Missing OpenAI API key.',
+			'[]',
+			'OpenAI',
+		);
+
 		$response = $open_ai->run(
 			[
 				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
@@ -229,6 +236,13 @@ class OpenAITest extends TestCase {
 					'open_ai_token' => 'age38gegewjdhagepkhif',
 				]
 			);
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Invalid prompt text.',
+			'[]',
+			'OpenAI',
+		);
 
 		$response = $open_ai->run(
 			[
@@ -302,6 +316,20 @@ class OpenAITest extends TestCase {
 		$chat_gpt->shouldReceive( 'chat' )
 			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
 
+		WP_Mock::expectAction(
+			'apbe_ai_provider_success_call',
+			'What a Wonderful World!',
+			'{"model":"gpt-3.5-turbo","temperature":1,"max_tokens":4000,"frequency_penalty":0,"presence_penalty":0,"messages":{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}}',
+			'OpenAI',
+		);
+
+		WP_Mock::expectFilter(
+			'apbe_ai_provider_response',
+			'What a Wonderful World!',
+			'{"model":"gpt-3.5-turbo","temperature":1,"max_tokens":4000,"frequency_penalty":0,"presence_penalty":0,"messages":{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}}',
+			'OpenAI',
+		);
+
 		$response = $open_ai->run(
 			[
 				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
@@ -318,6 +346,13 @@ class OpenAITest extends TestCase {
 
 		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'API Error...',
+			'[]',
+			'OpenAI',
+		);
 
 		$response = $open_ai->get_json_error( 'API Error...' );
 

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Providers;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Providers\OpenAI;
@@ -23,17 +24,66 @@ class OpenAITest extends TestCase {
 	public OpenAI $open_ai;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
 
 		$this->open_ai = new OpenAI();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_default_args() {
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_open_ai_args',
 			[
 				'model'             => 'gpt-3.5-turbo',

--- a/tests/php/Routes/SideBarTest.php
+++ b/tests/php/Routes/SideBarTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Routes;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Core\AI;
@@ -16,13 +17,13 @@ class SideBarTest extends TestCase {
 	public SideBar $sidebar;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->sidebar = new SideBar();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_route_initial_values() {
@@ -85,14 +86,14 @@ class SideBarTest extends TestCase {
 			'text'    => 'Hello World!',
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_feature_prompt',
 			'Generate an appropriate headline in 1 paragraph, using the following content: Hello World!. Do not include any explanation, commentary, or alternative suggestions.',
 			'headline',
 			'Hello World!'
 		);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -127,14 +128,14 @@ class SideBarTest extends TestCase {
 			'text'    => 'Hello World!',
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_feature_prompt',
 			'Generate an appropriate slug that can be found easily by search engines, using the following content: Hello World!. Do not include any explanation, commentary, or alternative suggestions.',
 			'slug',
 			'Hello World!'
 		);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -169,14 +170,14 @@ class SideBarTest extends TestCase {
 			'text'    => 'Hello World!',
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_feature_prompt',
 			'Generate appropriate keywords that are SEO friendly and separated with commas, using the following content: Hello World!. Do not include any explanation, commentary, or alternative suggestions.',
 			'keywords',
 			'Hello World!'
 		);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -211,14 +212,14 @@ class SideBarTest extends TestCase {
 			'text'    => 'Hello World!',
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_feature_prompt',
 			'Generate an appropriate summary for the following content: Hello World!. Do not include any explanation, commentary, or alternative suggestions.',
 			'summary',
 			'Hello World!'
 		);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -253,14 +254,14 @@ class SideBarTest extends TestCase {
 			'text'    => 'Hello World!',
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_feature_prompt',
 			'Generate appropriate social media trending hashtags for the following content: Hello World!. Do not include any explanation, commentary, or alternative suggestions.',
 			'social',
 			'Hello World!'
 		);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;

--- a/tests/php/Routes/SwitcherTest.php
+++ b/tests/php/Routes/SwitcherTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Routes;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Core\AI;
@@ -21,13 +22,13 @@ class SwitcherTest extends TestCase {
 	public Switcher $switcher;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->switcher = new Switcher();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_route_initial_values() {
@@ -71,14 +72,14 @@ class SwitcherTest extends TestCase {
 
 		$switcher->request = $request;
 
-		\WP_Mock::userFunction( 'wp_parse_args' )
+		WP_Mock::userFunction( 'wp_parse_args' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return array_merge( $arg2, $arg1 );
 				}
 			);
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn(
 				[
@@ -90,28 +91,28 @@ class SwitcherTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_attr' )
+		WP_Mock::userFunction( 'esc_attr' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'update_option' )
+		WP_Mock::userFunction( 'update_option' )
 			->with(
 				'ai_plus_block_editor',
 				[
@@ -123,7 +124,7 @@ class SwitcherTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					if ( $arg instanceof \WP_Error ) {

--- a/tests/php/Routes/ToneTest.php
+++ b/tests/php/Routes/ToneTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Routes;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Core\AI;
@@ -16,13 +17,13 @@ class ToneTest extends TestCase {
 	public Tone $tone;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->tone = new Tone();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_route_initial_values() {
@@ -85,14 +86,14 @@ class ToneTest extends TestCase {
 			'text' => 'Hello World!',
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'apbe_tone_prompt',
 			'Using a Casual tone, generate a text I can use to substitute the following text: Hello World!. Do not include any explanation, commentary, or alternative suggestions.',
 			'Casual',
 			'Hello World!'
 		);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;

--- a/tests/php/Services/AdminTest.php
+++ b/tests/php/Services/AdminTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Services;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Services\Admin;
@@ -22,9 +23,9 @@ class AdminTest extends TestCase {
 	public Admin $admin;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'ai_plus_block_editor', [] )
 			->andReturn( [] );
 
@@ -32,13 +33,13 @@ class AdminTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
-		\WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
-		\WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
+		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
+		WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
 
 		$this->admin->register();
 
@@ -46,7 +47,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_menu() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -55,7 +56,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -64,7 +65,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text ) {
@@ -73,7 +74,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'add_menu_page' )
+		WP_Mock::userFunction( 'add_menu_page' )
 			->once()
 			->with(
 				'AI + Block Editor',
@@ -93,7 +94,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_bails_out_if_any_nonce_settings_is_missing() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -102,7 +103,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -111,7 +112,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text ) {
@@ -136,7 +137,7 @@ class AdminTest extends TestCase {
 			'ai_plus_block_editor_settings_nonce' => 'a8vbq3cg3sa',
 		];
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -145,7 +146,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -154,7 +155,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text ) {
@@ -163,17 +164,17 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->times( 1 )
 			->with( 'a8vbq3cg3sa' )
 			->andReturn( 'a8vbq3cg3sa' );
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->times( 1 )
 			->with( 'a8vbq3cg3sa' )
 			->andReturn( 'a8vbq3cg3sa' );
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->once()
 			->with( 'a8vbq3cg3sa', 'ai_plus_block_editor_settings_action' )
 			->andReturn( false );
@@ -185,7 +186,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_passes() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -194,7 +195,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -203,7 +204,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text ) {
@@ -217,7 +218,7 @@ class AdminTest extends TestCase {
 			'ai_plus_block_editor_settings_nonce' => 'a8vbq3cg3sa',
 		];
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_unslash',
 			[
 				'return' => function ( $text ) {
@@ -226,19 +227,19 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->times( 1 )
 			->with( 'a8vbq3cg3sa', 'ai_plus_block_editor_settings_action' )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'update_option' )
+		WP_Mock::userFunction( 'update_option' )
 			->once()
 			->with(
 				'ai_plus_block_editor',
@@ -267,10 +268,10 @@ class AdminTest extends TestCase {
 		$screen->shouldAllowMockingProtectedMethods();
 		$screen->id = 'toplevel_page_ai-plus-block-editor';
 
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -279,7 +280,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text, $domain = 'ai-plus-block-editor' ) {
@@ -288,7 +289,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text ) {
@@ -299,11 +300,11 @@ class AdminTest extends TestCase {
 
 		$reflection = new \ReflectionClass( Admin::class );
 
-		\WP_Mock::userFunction( 'plugin_dir_url' )
+		WP_Mock::userFunction( 'plugin_dir_url' )
 			->with( $reflection->getFileName() )
 			->andReturn( 'https://example.com/wp-content/plugins/ai-plus-block-editor/inc/Services/' );
 
-		\WP_Mock::userFunction( 'wp_enqueue_style' )
+		WP_Mock::userFunction( 'wp_enqueue_style' )
 			->with(
 				'ai-plus-block-editor',
 				'https://example.com/wp-content/plugins/ai-plus-block-editor/inc/Services/../../styles.css',
@@ -319,7 +320,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_styles_bails() {
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( '' );
 
 		$this->admin->register_options_styles();

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Services;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Services\Boot;
@@ -22,18 +23,18 @@ class BootTest extends TestCase {
 	public Boot $boot;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->boot = new Boot();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'init', [ $this->boot, 'register_translation' ] );
-		\WP_Mock::expectActionAdded( 'enqueue_block_editor_assets', [ $this->boot, 'register_scripts' ] );
+		WP_Mock::expectActionAdded( 'init', [ $this->boot, 'register_translation' ] );
+		WP_Mock::expectActionAdded( 'enqueue_block_editor_assets', [ $this->boot, 'register_scripts' ] );
 
 		$this->boot->register();
 
@@ -64,18 +65,18 @@ class BootTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'plugins_url' )
+		WP_Mock::userFunction( 'plugins_url' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return sprintf( 'https://example.com/wp-content/plugins/%s', $arg );
 				}
 			);
 
-		\WP_Mock::userFunction( 'plugin_dir_path' )
+		WP_Mock::userFunction( 'plugin_dir_path' )
 			->with( $boot->getFileName() )
 			->andReturn( '/var/www/wp-content/plugins/ai-plus-block-editor/inc/Services/' );
 
-		\WP_Mock::userFunction( 'wp_enqueue_script' )
+		WP_Mock::userFunction( 'wp_enqueue_script' )
 			->with(
 				'ai-plus-block-editor',
 				'https://example.com/wp-content/plugins/ai-plus-block-editor/dist/app.js',
@@ -94,31 +95,31 @@ class BootTest extends TestCase {
 				false,
 			);
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_attr' )
+		WP_Mock::userFunction( 'esc_attr' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_localize_script' )
+		WP_Mock::userFunction( 'wp_localize_script' )
 			->andReturn( null );
 
-		\WP_Mock::userFunction( 'wp_set_script_translations' )
+		WP_Mock::userFunction( 'wp_set_script_translations' )
 			->with(
 				'ai-plus-block-editor',
 				'ai-plus-block-editor',
@@ -133,26 +134,26 @@ class BootTest extends TestCase {
 	public function test_register_translation() {
 		$boot = new \ReflectionClass( Boot::class );
 
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_attr' )
+		WP_Mock::userFunction( 'esc_attr' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'plugin_basename' )
+		WP_Mock::userFunction( 'plugin_basename' )
 			->once()
 			->with( $boot->getFileName() )
 			->andReturn( '/inc/Services/Boot.php' );
 
-		\WP_Mock::userFunction( 'load_plugin_textdomain' )
+		WP_Mock::userFunction( 'load_plugin_textdomain' )
 			->once()
 			->with(
 				'ai-plus-block-editor',

--- a/tests/php/Services/PostMetaTest.php
+++ b/tests/php/Services/PostMetaTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Services;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Services\PostMeta;
@@ -15,17 +16,17 @@ class PostMetaTest extends TestCase {
 	public PostMeta $post_meta;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->post_meta = new PostMeta();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'init', [ $this->post_meta, 'register_post_meta' ] );
+		WP_Mock::expectActionAdded( 'init', [ $this->post_meta, 'register_post_meta' ] );
 
 		$this->post_meta->register();
 
@@ -33,7 +34,7 @@ class PostMetaTest extends TestCase {
 	}
 
 	public function test_register_post_meta() {
-		\WP_Mock::onFilter( 'apbe_post_meta' )
+		WP_Mock::onFilter( 'apbe_post_meta' )
 			->with(
 				[
 					'apbe_headline',
@@ -49,7 +50,7 @@ class PostMetaTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'register_post_meta' )
+		WP_Mock::userFunction( 'register_post_meta' )
 			->with(
 				'',
 				'apbe_summary',

--- a/tests/php/Services/RoutesTest.php
+++ b/tests/php/Services/RoutesTest.php
@@ -2,6 +2,7 @@
 
 namespace AiPlusBlockEditor\Tests\Services;
 
+use WP_Mock;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use AiPlusBlockEditor\Routes\Tone;
@@ -19,17 +20,17 @@ class RoutesTest extends TestCase {
 	public Routes $routes;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->routes = new Routes();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'rest_api_init', [ $this->routes, 'register_rest_routes' ] );
+		WP_Mock::expectActionAdded( 'rest_api_init', [ $this->routes, 'register_rest_routes' ] );
 
 		$this->routes->register();
 
@@ -37,7 +38,7 @@ class RoutesTest extends TestCase {
 	}
 
 	public function test_register_rest_routes() {
-		\WP_Mock::onFilter( 'apbe_rest_routes' )
+		WP_Mock::onFilter( 'apbe_rest_routes' )
 			->with(
 				[
 					Tone::class,
@@ -53,7 +54,7 @@ class RoutesTest extends TestCase {
 
 		$sidebar = new SideBar();
 
-		\WP_Mock::userFunction( 'register_rest_route' )
+		WP_Mock::userFunction( 'register_rest_route' )
 			->with(
 				'ai-plus-block-editor/v1',
 				'/sidebar',


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/64).

## Description / Background Context

This PR focuses on improving the AI provider classes, adding custom filters, providing error logging capabilities and so on.

## Testing Instructions

1. Pull PR to local.
2. Observe that filters are now in place and work correctly.
3. Observe that error logging capabilities are now in place.
4. Observe that there are no regressions are introduced.