### PR TITLE
Fix: Load missing Grok AI provider client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `apbe_open_ai_system_prompt`.
 * Feat: Add error logging capabilities.
 * Feat: Implement AI provider abstraction.
+* Fix: Load missing Grok provider correctly.
 * Docs: Update README docs.
 * Test: Update unit tests.
 * Tested up to WP 6.8.2.

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -13,6 +13,8 @@ namespace AiPlusBlockEditor\Core;
 use AiPlusBlockEditor\Providers\OpenAI;
 use AiPlusBlockEditor\Providers\Gemini;
 use AiPlusBlockEditor\Providers\DeepSeek;
+use AiPlusBlockEditor\Providers\Grok;
+
 use AiPlusBlockEditor\Interfaces\Provider;
 
 class AI implements Provider {
@@ -40,6 +42,10 @@ class AI implements Provider {
 
 			case 'DeepSeek':
 				$ai_provider = DeepSeek::class;
+				break;
+
+			case 'Grok':
+				$ai_provider = Grok::class;
 				break;
 		}
 

--- a/inc/Core/Container.php
+++ b/inc/Core/Container.php
@@ -11,8 +11,8 @@
 namespace AiPlusBlockEditor\Core;
 
 use AiPlusBlockEditor\Services\Admin;
-use AiPlusBlockEditor\Services\PostMeta;
 use AiPlusBlockEditor\Services\Boot;
+use AiPlusBlockEditor\Services\PostMeta;
 use AiPlusBlockEditor\Services\Routes;
 use AiPlusBlockEditor\Interfaces\Kernel;
 
@@ -34,8 +34,8 @@ class Container implements Kernel {
 	public function __construct() {
 		static::$services = [
 			Admin::class,
-			PostMeta::class,
 			Boot::class,
+			PostMeta::class,
 			Routes::class,
 		];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
   - `apbe_open_ai_system_prompt`.
 * Feat: Add error logging capabilities.
 * Feat: Implement AI provider abstraction.
+* Fix: Load missing Grok provider correctly.
 * Docs: Update README docs.
 * Test: Update unit tests.
 * Tested up to WP 6.8.2.


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/65).

## Description / Background Context

At the moment, users are not able to use the Grok LLM. This is happening because we are missing the Grok provider in the AI factory class. We need to load this alongside the other providers so that users can be able to use same.

This PR fixes this issue correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `yarn build`.
3. Select the **Grok** AI provider.
4. Generate any of the sidebar features (headline, summary...).
5. Observe that it is working correctly.
6. All other features should work correctly as before without any regressions.