### PR TITLE
Feat: Implement Claude AI provider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
 # 1.8.0
+* Feat: Implement Claude AI provider.
 * Feat: Refactor AI providers.
 * Feat: Add custom filters:
   - `apbe_ai_provider_success_call`.
 	- `apbe_ai_provider_fail_call`.
 	- `apbe_ai_provider_response`.
+	- `apbe_claude_api_url`.
+	- `apbe_claude_args`.
+	- `apbe_claude_system_prompt`.
 	- `apbe_deepseek_system_prompt`.
   - `apbe_open_ai_system_prompt`.
 * Feat: Add error logging capabilities.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,63 @@ public function log_failed_provider_call( $message, $payload, $provider ) {
 - $provider _`{string}`_ By default this will be a string containing the provider name.
 <br/>
 
+#### `apbe_claude_api_url`
+
+This custom hook (filter) provides the ability to modify the Claude endpoint used for generating AI content.
+
+```php
+add_filter( 'apbe_claude_api_url', [ $this, 'custom_api_url' ], 10, 1 );
+
+public function custom_api_url( $url ) {
+    return esc_url( 'https://api.anthropic.com/v2/messages' );
+}
+```
+
+**Parameters**
+
+- url _`{string}`_ By default this will be a string containing the API endpoint for the Claude LLM.
+<br/>
+
+#### `apbe_claude_args`
+
+This custom hook (filter) provides the ability to modify the Claude args before it is sent to the LLM.
+
+```php
+add_filter( 'apbe_claude_args', [ $this, 'custom_args' ], 10, 1 );
+
+public function custom_args( $args ) {
+    return wp_parse_args(
+        [
+            'model'      => 'claude-4-genius',
+            'max_tokens' => 1024,
+        ],
+        $args
+    )
+}
+```
+
+**Parameters**
+
+- args _`{array}`_ By default this will be an array containing the Claude default parameters.
+<br/>
+
+#### `apbe_claude_system_prompt`
+
+This custom hook (filter) provides the ability to modify the Claude system prompt.
+
+```php
+add_filter( 'apbe_claude_system_prompt', [ $this, 'custom_system_prompt' ], 10, 1 );
+
+public function custom_system_prompt( $prompt ) {
+    return esc_html( 'You are Claude, a super-intelligent Journalist writing a cover story.' );
+}
+```
+
+**Parameters**
+
+- prompt _`{string}`_ By default this will be a string containing the default system prompt.
+<br/>
+
 #### `apbe_deepseek_api_url`
 
 This custom hook (filter) provides the ability to modify the DeepSeek endpoint used for generating AI content.

--- a/inc/Abstracts/Provider.php
+++ b/inc/Abstracts/Provider.php
@@ -57,11 +57,10 @@ abstract class Provider implements ProviderInterface {
 	 *
 	 * @param string $response Success response.
 	 * @param string $payload  JSON Payload.
-	 * @param string $provider Provider class.
 	 *
 	 * @return string
 	 */
-	protected function get_provider_response( $response, $payload, $provider ): string {
+	protected function get_provider_response( $response, $payload ): string {
 		/**
 		 * Fire on successful Provider call.
 		 *
@@ -76,7 +75,7 @@ abstract class Provider implements ProviderInterface {
 		 *
 		 * @return void
 		 */
-		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
+		do_action( 'apbe_ai_provider_success_call', $response, $payload, static::$name );
 
 		/**
 		 * Filter API response.
@@ -92,7 +91,7 @@ abstract class Provider implements ProviderInterface {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+		return apply_filters( 'apbe_ai_provider_response', $response, $payload, static::$name );
 	}
 
 	/**

--- a/inc/Abstracts/Provider.php
+++ b/inc/Abstracts/Provider.php
@@ -35,7 +35,7 @@ abstract class Provider implements ProviderInterface {
 	 *
 	 * @return mixed[]
 	 */
-	abstract protected function get_default_args();
+	abstract protected function get_default_args(): array;
 
 	/**
 	 * Run AI Prompt.
@@ -104,7 +104,7 @@ abstract class Provider implements ProviderInterface {
 	 *
 	 * @return \WP_Error
 	 */
-	protected function get_json_error( $message, $body = [] ) {
+	protected function get_json_error( $message, $body = [] ): \WP_Error {
 		// Get Payload.
 		$payload = wp_json_encode( $body );
 

--- a/inc/Abstracts/Provider.php
+++ b/inc/Abstracts/Provider.php
@@ -51,6 +51,51 @@ abstract class Provider implements ProviderInterface {
 	abstract public function run( $payload );
 
 	/**
+	 * Get Provider Response.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $response Success response.
+	 * @param string $payload  JSON Payload.
+	 * @param string $provider Provider class.
+	 *
+	 * @return string
+	 */
+	protected function get_provider_response( $response, $payload, $provider ): string {
+		/**
+		 * Fire on successful Provider call.
+		 *
+		 * This provides a way to fire events on
+		 * successful AI Provider calls.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return void
+		 */
+		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
+
+		/**
+		 * Filter API response.
+		 *
+		 * This provides a way to filter the LLM
+		 * API response.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+	}
+
+	/**
 	 * Get JSON Error.
 	 *
 	 * @since 1.8.0

--- a/inc/Abstracts/Route.php
+++ b/inc/Abstracts/Route.php
@@ -95,7 +95,7 @@ abstract class Route implements Router {
 	/**
 	 * Get AI Client.
 	 *
-	 * @since TBD
+	 * @since 1.1.2
 	 *
 	 * @param Provider $provider
 	 * @return Provider

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -136,6 +136,7 @@ class Options {
 							'Gemini'   => 'Gemini',
 							'DeepSeek' => 'DeepSeek',
 							'Grok'     => 'Grok',
+							'Claude'   => 'Claude',
 						],
 					],
 				],
@@ -197,6 +198,22 @@ class Options {
 						'summary' => esc_html__( 'Use Grok capabilities in Block Editor', 'ai-plus-block-editor' ),
 					],
 					'grok_token'  => [
+						'control'     => esc_attr( 'password' ),
+						'placeholder' => esc_attr( '' ),
+						'label'       => esc_html__( 'API Keys', 'ai-plus-block-editor' ),
+						'summary'     => esc_html__( 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av', 'ai-plus-block-editor' ),
+					],
+				],
+			],
+			'claude_options'        => [
+				'heading'  => esc_html__( 'Claude', 'ai-plus-block-editor' ),
+				'controls' => [
+					'claude_enable' => [
+						'control' => esc_attr( 'checkbox' ),
+						'label'   => esc_html__( 'Enable Claude', 'ai-plus-block-editor' ),
+						'summary' => esc_html__( 'Use Claude capabilities in Block Editor', 'ai-plus-block-editor' ),
+					],
+					'claude_token'  => [
 						'control'     => esc_attr( 'password' ),
 						'placeholder' => esc_attr( '' ),
 						'label'       => esc_html__( 'API Keys', 'ai-plus-block-editor' ),

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -14,6 +14,7 @@ use AiPlusBlockEditor\Providers\OpenAI;
 use AiPlusBlockEditor\Providers\Gemini;
 use AiPlusBlockEditor\Providers\DeepSeek;
 use AiPlusBlockEditor\Providers\Grok;
+use AiPlusBlockEditor\Providers\Claude;
 
 use AiPlusBlockEditor\Interfaces\Provider;
 
@@ -46,6 +47,10 @@ class AI implements Provider {
 
 			case 'Grok':
 				$ai_provider = Grok::class;
+				break;
+
+			case 'Claude':
+				$ai_provider = Claude::class;
 				break;
 		}
 

--- a/inc/Core/AI.php
+++ b/inc/Core/AI.php
@@ -59,7 +59,7 @@ class AI implements Provider {
 	 * correctly mocking and writing tests for the
 	 * `get_provider` method.
 	 *
-	 * @since TBD
+	 * @since 1.1.2
 	 *
 	 * @param Provider $provider
 	 * @return Provider

--- a/inc/Providers/Claude.php
+++ b/inc/Providers/Claude.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Claude Class.
+ *
+ * This class is responsible for handling
+ * Claude calls.
+ *
+ * @package AiPlusBlockEditor
+ */
+
+namespace AiPlusBlockEditor\Providers;
+
+use AiPlusBlockEditor\Admin\Options;
+use AiPlusBlockEditor\Abstracts\Provider;
+use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
+
+class Claude extends Provider implements ProviderInterface {
+	/**
+	 * Get Default Args.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return mixed[]
+	 */
+	protected function get_default_args(): array {
+		$args = [
+			'model'      => 'claude-3-opus-20240229',
+			'max_tokens' => 512,
+		];
+
+		/**
+		 * Filter Claude default args.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param mixed[] $args Default args.
+		 * @return mixed[]
+		 */
+		$filtered_args = (array) apply_filters( 'apbe_claude_args', $args );
+
+		return wp_parse_args( $filtered_args, $args );
+	}
+
+	/**
+	 * Get API URL.
+	 *
+	 * This method returns the Claude API URL
+	 * endpoint. It can be filtered using the
+	 * 'apbe_claude_api_url' filter.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return string
+	 */
+	protected function get_api_url(): string {
+		$url = 'https://api.anthropic.com/v1/messages';
+
+		/**
+		 * Filter Claude API URL.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $url Claude API URL.
+		 * @return string
+		 */
+		return esc_url( (string) apply_filters( 'apbe_claude_api_url', $url ) );
+	}
+
+	/**
+	 * Get AI Response.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param mixed[] $payload JSON Payload.
+	 * @return string|\WP_Error
+	 */
+	public function run( $payload ) {
+		$api_key = get_option( Options::get_page_option(), [] )['claude_token'] ?? '';
+
+		if ( empty( $api_key ) ) {
+			return $this->get_json_error(
+				__( 'Missing Claude API key.', 'ai-plus-block-editor' )
+			);
+		}
+
+		// Default prompt if not passed.
+		$prompt_text = $payload['content'] ?? '';
+
+		// Validate prompt text.
+		if ( ! is_string( $prompt_text ) || empty( $prompt_text ) ) {
+			return $this->get_json_error(
+				__( 'Invalid prompt text.', 'ai-plus-block-editor' )
+			);
+		}
+
+		// Claude API expects a specific body structure.
+		$body = wp_parse_args(
+			[
+				'messages' => [
+					[
+						'role'    => 'user',
+						'content' => $prompt_text,
+					],
+				],
+			],
+			$this->get_default_args()
+		);
+
+		$response = wp_remote_post(
+			$this->get_api_url(),
+			[
+				'headers' => [
+					'Content-Type'      => 'application/json',
+					'x-api-key'         => $api_key,
+					'anthropic-version' => '2023-06-01',
+				],
+				'body'    => wp_json_encode( $body, JSON_UNESCAPED_UNICODE ),
+				'timeout' => 20,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $this->get_json_error( $response->get_error_message() );
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		// Notify user, if JSON yields null.
+		if ( empty( $data ) || ! isset( $data['choices'][0]['message']['content'] ) ) {
+			return $this->get_json_error(
+				$data['error']['message'] ?? __( 'Unexpected Claude API response.', 'ai-plus-block-editor' )
+			);
+		}
+
+		return $data['choices'][0]['message']['content'] ?? '';
+	}
+}

--- a/inc/Providers/Claude.php
+++ b/inc/Providers/Claude.php
@@ -159,42 +159,7 @@ class Claude extends Provider implements ProviderInterface {
 		// Get API response.
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
-		// Get Payload.
-		$payload = wp_json_encode( $body );
-
-		// Get Provider name.
-		$provider = static::$name;
-
-		/**
-		 * Fire on successful Provider call.
-		 *
-		 * This provides a way to fire events on
-		 * successful AI Provider calls.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return void
-		 */
-		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
-
-		/**
-		 * Filter API response.
-		 *
-		 * This provides a way to filter the LLM
-		 * API response.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return string
-		 */
-		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+		// Return filtered response.
+		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
 	}
 }

--- a/inc/Providers/Claude.php
+++ b/inc/Providers/Claude.php
@@ -16,6 +16,15 @@ use AiPlusBlockEditor\Interfaces\Provider as ProviderInterface;
 
 class Claude extends Provider implements ProviderInterface {
 	/**
+	 * Provider name.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var string
+	 */
+	protected static $name = 'Claude';
+
+	/**
 	 * Get Default Args.
 	 *
 	 * @since 1.8.0
@@ -124,8 +133,8 @@ class Claude extends Provider implements ProviderInterface {
 			$this->get_api_url(),
 			[
 				'headers' => [
-					'Content-Type'      => 'application/json',
 					'x-api-key'         => $api_key,
+					'Content-Type'      => 'application/json',
 					'anthropic-version' => '2023-06-01',
 				],
 				'body'    => wp_json_encode( $body, JSON_UNESCAPED_UNICODE ),
@@ -134,7 +143,7 @@ class Claude extends Provider implements ProviderInterface {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $this->get_json_error( $response->get_error_message() );
+			return $this->get_json_error( $response->get_error_message(), $body );
 		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
@@ -142,10 +151,50 @@ class Claude extends Provider implements ProviderInterface {
 		// Notify user, if JSON yields null.
 		if ( empty( $data ) || ! isset( $data['choices'][0]['message']['content'] ) ) {
 			return $this->get_json_error(
-				$data['error']['message'] ?? __( 'Unexpected Claude API response.', 'ai-plus-block-editor' )
+				$data['error']['message'] ?? __( 'Unexpected Claude API response.', 'ai-plus-block-editor' ),
+				$body
 			);
 		}
 
-		return $data['choices'][0]['message']['content'] ?? '';
+		// Get API response.
+		$response = $data['choices'][0]['message']['content'] ?? '';
+
+		// Get Payload.
+		$payload = wp_json_encode( $body );
+
+		// Get Provider name.
+		$provider = static::$name;
+
+		/**
+		 * Fire on successful Provider call.
+		 *
+		 * This provides a way to fire events on
+		 * successful AI Provider calls.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return void
+		 */
+		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
+
+		/**
+		 * Filter API response.
+		 *
+		 * This provides a way to filter the LLM
+		 * API response.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $response Success response.
+		 * @param string $payload  JSON Payload.
+		 * @param string $provider Provider class.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
 	}
 }

--- a/inc/Providers/Claude.php
+++ b/inc/Providers/Claude.php
@@ -93,10 +93,24 @@ class Claude extends Provider implements ProviderInterface {
 			);
 		}
 
+		/**
+		 * Filter Claude System Prompt.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string $prompt Claude System prompt.
+		 * @return string
+		 */
+		$system_prompt = apply_filters( 'apbe_claude_system_prompt', 'You are Claude, a highly intelligent, helpful AI assistant.' );
+
 		// Claude API expects a specific body structure.
 		$body = wp_parse_args(
 			[
 				'messages' => [
+					[
+						'role'    => 'system',
+						'content' => $system_prompt,
+					],
 					[
 						'role'    => 'user',
 						'content' => $prompt_text,

--- a/inc/Providers/Claude.php
+++ b/inc/Providers/Claude.php
@@ -160,6 +160,6 @@ class Claude extends Provider implements ProviderInterface {
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
 		// Return filtered response.
-		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
+		return $this->get_provider_response( $response, wp_json_encode( $body ) );
 	}
 }

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -163,6 +163,6 @@ class DeepSeek extends Provider implements ProviderInterface {
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
 		// Return filtered response.
-		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
+		return $this->get_provider_response( $response, wp_json_encode( $body ) );
 	}
 }

--- a/inc/Providers/DeepSeek.php
+++ b/inc/Providers/DeepSeek.php
@@ -162,42 +162,7 @@ class DeepSeek extends Provider implements ProviderInterface {
 		// Get API response.
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
-		// Get Payload.
-		$payload = wp_json_encode( $body );
-
-		// Get Provider name.
-		$provider = static::$name;
-
-		/**
-		 * Fire on successful Provider call.
-		 *
-		 * This provides a way to fire events on
-		 * successful AI Provider calls.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return void
-		 */
-		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
-
-		/**
-		 * Filter API response.
-		 *
-		 * This provides a way to filter the LLM
-		 * API response.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return string
-		 */
-		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+		// Return filtered response.
+		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
 	}
 }

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -153,42 +153,7 @@ class Gemini extends Provider implements ProviderInterface {
 		// Get API response.
 		$response = $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
 
-		// Get Payload.
-		$payload = wp_json_encode( $body );
-
-		// Get Provider name.
-		$provider = static::$name;
-
-		/**
-		 * Fire on successful Provider call.
-		 *
-		 * This provides a way to fire events on
-		 * successful AI Provider calls.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return void
-		 */
-		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
-
-		/**
-		 * Filter API response.
-		 *
-		 * This provides a way to filter the LLM
-		 * API response.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return string
-		 */
-		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+		// Return filtered response.
+		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
 	}
 }

--- a/inc/Providers/Gemini.php
+++ b/inc/Providers/Gemini.php
@@ -154,6 +154,6 @@ class Gemini extends Provider implements ProviderInterface {
 		$response = $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
 
 		// Return filtered response.
-		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
+		return $this->get_provider_response( $response, wp_json_encode( $body ) );
 	}
 }

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -159,6 +159,6 @@ class Grok extends Provider implements ProviderInterface {
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
 		// Return filtered response.
-		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
+		return $this->get_provider_response( $response, wp_json_encode( $body ) );
 	}
 }

--- a/inc/Providers/Grok.php
+++ b/inc/Providers/Grok.php
@@ -158,42 +158,7 @@ class Grok extends Provider implements ProviderInterface {
 		// Get API response.
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
-		// Get Payload.
-		$payload = wp_json_encode( $body );
-
-		// Get Provider name.
-		$provider = static::$name;
-
-		/**
-		 * Fire on successful Provider call.
-		 *
-		 * This provides a way to fire events on
-		 * successful AI Provider calls.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return void
-		 */
-		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
-
-		/**
-		 * Filter API response.
-		 *
-		 * This provides a way to filter the LLM
-		 * API response.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return string
-		 */
-		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+		// Return filtered response.
+		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
 	}
 }

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -161,42 +161,7 @@ class OpenAI extends Provider implements ProviderInterface {
 		// Get API response.
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
-		// Get Payload.
-		$payload = wp_json_encode( $body );
-
-		// Get Provider name.
-		$provider = static::$name;
-
-		/**
-		 * Fire on successful Provider call.
-		 *
-		 * This provides a way to fire events on
-		 * successful AI Provider calls.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return void
-		 */
-		do_action( 'apbe_ai_provider_success_call', $response, $payload, $provider );
-
-		/**
-		 * Filter API response.
-		 *
-		 * This provides a way to filter the LLM
-		 * API response.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string $response Success response.
-		 * @param string $payload  JSON Payload.
-		 * @param string $provider Provider class.
-		 *
-		 * @return string
-		 */
-		return apply_filters( 'apbe_ai_provider_response', $response, $payload, $provider );
+		// Return filtered response.
+		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
 	}
 }

--- a/inc/Providers/OpenAI.php
+++ b/inc/Providers/OpenAI.php
@@ -162,6 +162,6 @@ class OpenAI extends Provider implements ProviderInterface {
 		$response = $data['choices'][0]['message']['content'] ?? '';
 
 		// Return filtered response.
-		return $this->get_provider_response( $response, wp_json_encode( $body ), static::$name );
+		return $this->get_provider_response( $response, wp_json_encode( $body ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ Save time and improve engagement with AI-powered insights directly within the Wo
 
 Our plugin comes with everything you need to add AI capabilities to your Block Editor.
 
-✔️ <strong>Support for LLMs</strong> such as <strong>ChatGPT, Gemini, Deepseek, Grok</strong> and a host of others.
+✔️ <strong>Support for LLMs</strong> such as <strong>ChatGPT, Gemini, Deepseek, Grok, Claude</strong> and a host of others.
 ✔️ <strong>Change Text Tone (casual, official, narrative, and so on...)</strong> in block editor.
 ✔️ <strong>Generate Title/Headline</strong> using AI.
 ✔️ <strong>Generate Summary/Excerpts</strong>.
@@ -69,11 +69,15 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.8.0 =
+* Feat: Implement Claude AI provider.
 * Feat: Refactor AI providers.
 * Feat: Add custom filters:
   - `apbe_ai_provider_success_call`.
   - `apbe_ai_provider_fail_call`.
   - `apbe_ai_provider_response`.
+  - `apbe_claude_api_url`.
+  - `apbe_claude_args`.
+  - `apbe_claude_system_prompt`.
   - `apbe_deepseek_system_prompt`.
   - `apbe_open_ai_system_prompt`.
 * Feat: Add error logging capabilities.

--- a/src/components/Switcher.tsx
+++ b/src/components/Switcher.tsx
@@ -76,6 +76,7 @@ const Switcher = (): JSX.Element => {
 					{ label: 'Gemini', value: 'Gemini' },
 					{ label: 'DeepSeek', value: 'DeepSeek' },
 					{ label: 'Grok', value: 'Grok' },
+					{ label: 'Claude', value: 'Claude' },
 				] }
 				onChange={ handleChange }
 				id="switcher"

--- a/tests/js/Switcher.test.tsx
+++ b/tests/js/Switcher.test.tsx
@@ -82,6 +82,7 @@ describe( 'Switcher', () => {
 		expect( getByText( 'Gemini' ) ).toBeVisible();
 		expect( getByText( 'DeepSeek' ) ).toBeVisible();
 		expect( getByText( 'Grok' ) ).toBeVisible();
+		expect( getByText( 'Claude' ) ).toBeVisible();
 	} );
 
 	it( 'makes an API call request on selection change', async () => {

--- a/tests/js/__snapshots__/Switcher.test.tsx.snap
+++ b/tests/js/__snapshots__/Switcher.test.tsx.snap
@@ -31,6 +31,11 @@ exports[`Switcher renders Switcher component 1`] = `
     >
       Grok
     </option>
+    <option
+      value="Claude"
+    >
+      Claude
+    </option>
   </select>
 </div>
 `;

--- a/tests/php/Abstracts/ProviderTest.php
+++ b/tests/php/Abstracts/ProviderTest.php
@@ -80,10 +80,37 @@ class ProviderTest extends TestCase {
 
 		$this->assertSame(
 			[
-				'model' => 'ai_model',
+				'model' => 'ai-model',
 			],
 			$response
 		);
+	}
+
+	public function test_get_provider_response() {
+		$payload = [
+			'model'  => 'ai-model',
+			'tokens' => 512,
+			'stream' => false,
+		];
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_success_call',
+			'What a Wonderful World!',
+			wp_json_encode( $payload ),
+			'AI Provider',
+		);
+
+		WP_Mock::expectFilter(
+			'apbe_ai_provider_response',
+			'What a Wonderful World!',
+			wp_json_encode( $payload ),
+			'AI Provider',
+		);
+
+		$response = $this->provider->get_provider_response( 'What a Wonderful World!', wp_json_encode( $payload ) );
+
+		$this->assertSame( 'What a Wonderful World!', $response );
+		$this->assertConditionsMet();
 	}
 
 	public function test_get_json_error() {
@@ -120,13 +147,13 @@ class ProviderTest extends TestCase {
 class ConcreteProvider extends Provider {
 	protected static $name = 'AI Provider';
 
-	protected function get_default_args() {
-		return [
-			'model' => 'ai_model',
-		];
-	}
-
 	public function run( $payload ) {
 		echo wp_json_encode( $payload );
+	}
+
+	protected function get_default_args(): array {
+		return [
+			'model' => 'ai-model',
+		];
 	}
 }

--- a/tests/php/Abstracts/ProviderTest.php
+++ b/tests/php/Abstracts/ProviderTest.php
@@ -9,6 +9,7 @@ use AiPlusBlockEditor\Abstracts\Provider;
 
 /**
  * @covers \AiPlusBlockEditor\Abstracts\Provider::get_default_args
+ * @covers \AiPlusBlockEditor\Abstracts\Provider::get_provider_response
  * @covers \AiPlusBlockEditor\Abstracts\Provider::get_json_error
  * @covers \AiPlusBlockEditor\Abstracts\Provider::run
  */

--- a/tests/php/Admin/OptionsTest.php
+++ b/tests/php/Admin/OptionsTest.php
@@ -120,6 +120,7 @@ class OptionsTest extends TestCase {
 								'Gemini'   => 'Gemini',
 								'DeepSeek' => 'DeepSeek',
 								'Grok'     => 'Grok',
+								'Claude'   => 'Claude',
 							],
 						],
 					],
@@ -181,6 +182,22 @@ class OptionsTest extends TestCase {
 							'summary' => 'Use Grok capabilities in Block Editor',
 						],
 						'grok_token'  => [
+							'control'     => 'password',
+							'placeholder' => '',
+							'label'       => 'API Keys',
+							'summary'     => 'e.g. ae2kgch7ib9eqcbeveq9a923nv87392av',
+						],
+					],
+				],
+				'claude_options'        => [
+					'heading'  => 'Claude',
+					'controls' => [
+						'claude_enable' => [
+							'control' => 'checkbox',
+							'label'   => 'Enable Claude',
+							'summary' => 'Use Claude capabilities in Block Editor',
+						],
+						'claude_token'  => [
 							'control'     => 'password',
 							'placeholder' => '',
 							'label'       => 'API Keys',

--- a/tests/php/Providers/ClaudeTest.php
+++ b/tests/php/Providers/ClaudeTest.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace AiPlusBlockEditor\Tests\Providers;
+
+use WP_Mock;
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use AiPlusBlockEditor\Providers\Claude;
+
+/**
+ * @covers \AiPlusBlockEditor\Providers\Claude::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\Claude::get_api_url
+ * @covers \AiPlusBlockEditor\Providers\Claude::run
+ * @covers \AiPlusBlockEditor\Providers\Claude::get_json_error
+ * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_notice
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_page
+ * @covers \AiPlusBlockEditor\Admin\Options::get_form_submit
+ * @covers \AiPlusBlockEditor\Admin\Options::init
+ */
+class ClaudeTest extends TestCase {
+	public Claude $claude;
+
+	public function setUp(): void {
+		WP_Mock::setUp();
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return json_encode( $arg );
+				}
+			);
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return array_merge( $arg2, $arg1 );
+				}
+			);
+
+		$this->claude = new Claude();
+	}
+
+	public function tearDown(): void {
+		WP_Mock::tearDown();
+	}
+
+	public function test_get_default_args() {
+		WP_Mock::expectFilter(
+			'apbe_claude_args',
+			[
+				'model'      => 'claude-3-opus-20240229',
+				'max_tokens' => 512,
+			]
+		);
+
+		$reflection = new \ReflectionClass( $this->claude );
+		$method     = $reflection->getMethod( 'get_default_args' );
+
+		$method->setAccessible( true );
+		$args = $method->invoke( $this->claude );
+
+		$this->assertSame(
+			$args,
+			[
+				'model'      => 'claude-3-opus-20240229',
+				'max_tokens' => 512,
+			]
+		);
+	}
+
+	public function test_get_api_url() {
+		$claude = Mockery::mock( Claude::class )->makePartial();
+		$claude->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::expectFilter(
+			'apbe_claude_api_url',
+			'https://api.anthropic.com/v1/messages'
+		);
+
+		$url = $claude->get_api_url();
+
+		$this->assertSame( $url, 'https://api.anthropic.com/v1/messages' );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_api_keys_and_returns_wp_error() {
+		$claude = Mockery::mock( Claude::class )->makePartial();
+		$claude->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'claude_token' => '',
+				]
+			);
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Missing Claude API key.',
+			'[]',
+			'Claude',
+		);
+
+		$response = $claude->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_if_missing_prompt_text_and_returns_wp_error() {
+		$claude = Mockery::mock( Claude::class )->makePartial();
+		$claude->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'claude_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Invalid prompt text.',
+			'[]',
+			'Claude',
+		);
+
+		$response = $claude->run(
+			[
+				'content' => '',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run_fails_returns_wp_error_if_malformed_JSON_is_returned() {
+		$claude = Mockery::mock( Claude::class )->makePartial();
+		$claude->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$claude->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model'  => 'grok-4',
+					'stream' => false,
+				]
+			);
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'claude_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		WP_Mock::expectFilter(
+			'apbe_claude_system_prompt',
+			'You are Claude, a highly intelligent, helpful AI assistant.'
+		);
+
+		$claude->shouldReceive( 'get_api_url' )
+			->andReturn( '' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn( '{"body":{"choices":[{"message":{"content":"What a Wonderful World!"}}]}}' );
+
+		// Return malformed JSON response
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( '{"choices":[{"message":{"content":' );
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'Unexpected Claude API response.',
+			'{"model":"grok-4","stream":false,"messages":[{"role":"system","content":"You are Claude, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
+			'Claude',
+		);
+
+		$response = $claude->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_run() {
+		$claude = Mockery::mock( Claude::class )->makePartial();
+		$claude->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		$claude->shouldReceive( 'get_default_args' )
+			->andReturn(
+				[
+					'model'  => 'grok-4',
+					'stream' => false,
+				]
+			);
+
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'ai_plus_block_editor', [] )
+			->andReturn(
+				[
+					'claude_token' => 'age38gegewjdhagepkhif',
+				]
+			);
+
+		WP_Mock::expectFilter(
+			'apbe_claude_system_prompt',
+			'You are Claude, a highly intelligent, helpful AI assistant.'
+		);
+
+		$claude->shouldReceive( 'get_api_url' )
+			->andReturn( '' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn( '{"body":{"choices":[{"message":{"content":"What a Wonderful World!"}}]}}' );
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( '{"choices":[{"message":{"content":"What a Wonderful World!"}}]}' );
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_success_call',
+			'What a Wonderful World!',
+			'{"model":"grok-4","stream":false,"messages":[{"role":"system","content":"You are Claude, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
+			'Claude',
+		);
+
+		WP_Mock::expectFilter(
+			'apbe_ai_provider_response',
+			'What a Wonderful World!',
+			'{"model":"grok-4","stream":false,"messages":[{"role":"system","content":"You are Claude, a highly intelligent, helpful AI assistant."},{"role":"user","content":"Generate me an SEO friendly Headline using: Hello World!"}]}',
+			'Claude',
+		);
+
+		$response = $claude->run(
+			[
+				'content' => 'Generate me an SEO friendly Headline using: Hello World!',
+			]
+		);
+
+		$this->assertSame( 'What a Wonderful World!', $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_json_error() {
+		$claude = Mockery::mock( Claude::class )->makePartial();
+		$claude->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::expectAction(
+			'apbe_ai_provider_fail_call',
+			'API Error...',
+			'[]',
+			'Claude',
+		);
+
+		$response = $claude->get_json_error( 'API Error...' );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/php/Providers/ClaudeTest.php
+++ b/tests/php/Providers/ClaudeTest.php
@@ -11,6 +11,7 @@ use AiPlusBlockEditor\Providers\Claude;
  * @covers \AiPlusBlockEditor\Providers\Claude::get_default_args
  * @covers \AiPlusBlockEditor\Providers\Claude::get_api_url
  * @covers \AiPlusBlockEditor\Providers\Claude::run
+ * @covers \AiPlusBlockEditor\Providers\Claude::get_provider_response
  * @covers \AiPlusBlockEditor\Providers\Claude::get_json_error
  * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
  * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields

--- a/tests/php/Providers/DeepSeekTest.php
+++ b/tests/php/Providers/DeepSeekTest.php
@@ -11,6 +11,7 @@ use AiPlusBlockEditor\Providers\DeepSeek;
  * @covers \AiPlusBlockEditor\Providers\DeepSeek::run
  * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_api_url
  * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_provider_response
  * @covers \AiPlusBlockEditor\Providers\DeepSeek::get_json_error
  * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
  * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields

--- a/tests/php/Providers/GeminiTest.php
+++ b/tests/php/Providers/GeminiTest.php
@@ -11,6 +11,7 @@ use AiPlusBlockEditor\Providers\Gemini;
  * @covers \AiPlusBlockEditor\Providers\Gemini::run
  * @covers \AiPlusBlockEditor\Providers\Gemini::get_api_url
  * @covers \AiPlusBlockEditor\Providers\Gemini::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\Gemini::get_provider_response
  * @covers \AiPlusBlockEditor\Providers\Gemini::get_json_error
  * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
  * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields

--- a/tests/php/Providers/GrokTest.php
+++ b/tests/php/Providers/GrokTest.php
@@ -11,6 +11,7 @@ use AiPlusBlockEditor\Providers\Grok;
  * @covers \AiPlusBlockEditor\Providers\Grok::get_default_args
  * @covers \AiPlusBlockEditor\Providers\Grok::get_api_url
  * @covers \AiPlusBlockEditor\Providers\Grok::run
+ * @covers \AiPlusBlockEditor\Providers\Grok::get_provider_response
  * @covers \AiPlusBlockEditor\Providers\Grok::get_json_error
  * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
  * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields

--- a/tests/php/Providers/OpenAITest.php
+++ b/tests/php/Providers/OpenAITest.php
@@ -11,6 +11,7 @@ use Orhanerday\OpenAi\OpenAi as ChatGPT;
 /**
  * @covers \AiPlusBlockEditor\Providers\OpenAI::run
  * @covers \AiPlusBlockEditor\Providers\OpenAI::get_default_args
+ * @covers \AiPlusBlockEditor\Providers\OpenAI::get_provider_response
  * @covers \AiPlusBlockEditor\Providers\OpenAI::get_json_error
  * @covers \AiPlusBlockEditor\Admin\Options::__callStatic
  * @covers \AiPlusBlockEditor\Admin\Options::get_form_fields

--- a/tests/php/Services/AdminTest.php
+++ b/tests/php/Services/AdminTest.php
@@ -244,6 +244,8 @@ class AdminTest extends TestCase {
 			->with(
 				'ai_plus_block_editor',
 				[
+					'claude_enable'        => '',
+					'claude_token'         => '',
 					'grok_enable'          => '',
 					'grok_token'           => '',
 					'deepseek_enable'      => '',


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/ai-plus-block-editor/issues/56).

## Description / Background Context

At the moment, we currently have the OpenAI provider in place, which works correctly for users as expected. As a step further, we would like to implement the Anthropic Claude AI provider to enable users use Claude as their AI option of choice. For reference pls see [Anthropic API](https://docs.anthropic.com/en/docs/get-started) link.

This PR focuses on implementing this correctly.

<img width="286" height="214" alt="Screenshot 2025-10-08 at 07 07 41" src="https://github.com/user-attachments/assets/71687492-806f-4588-909b-15859aa192d7" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `yarn build`.
3. Select the **Claude** AI provider.
4. Generate any of the sidebar features (headline, summary...).
5. Observe that it is working correctly.
6. All other features should work correctly as before without any regressions.